### PR TITLE
Build containers with go-1.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ POLICYDIR=/etc/selinux.d
 
 SRC=$(shell find . -name "*.go")
 
+GO?=go
+
 # External Helper variables
 
 GOLANGCI_LINT_VERSION=1.33.0
@@ -35,15 +37,15 @@ all: build
 build: $(BIN)
 
 $(BIN): $(BINDIR) $(SRC) pkg/semodule/semanage/callbacks.c
-	go build -o $(BIN) .
+	$(GO) build -o $(BIN) .
 
 .PHONY: test
 test:
-	go test -race github.com/containers/selinuxd/pkg/...
+	$(GO) test -race github.com/containers/selinuxd/pkg/...
 
 .PHONY: e2e
 e2e:
-	go test ./tests/e2e -timeout 40m -v --ginkgo.v
+	$(GO) test ./tests/e2e -timeout 40m -v --ginkgo.v
 
 
 .PHONY: run
@@ -70,7 +72,7 @@ verify: mod-verify verify-go-lint ## Run code lint checks
 
 .PHONY: mod-verify
 mod-verify:
-	@go mod verify
+	@$(GO) mod verify
 
 .PHONY: verify-go-lint
 verify-go-lint: golangci-lint ## Verify the golang code by linting

--- a/images/Dockerfile.centos
+++ b/images/Dockerfile.centos
@@ -13,21 +13,28 @@
 # limitations under the License.
 
 FROM registry.centos.org/centos:8 AS build
+ARG GO_VERSION=go1.17.3
+ENV GOPATH="/go"
+ENV PATH="$GOPATH/bin:$PATH"
 USER root
 WORKDIR /work
 
-# Speed up build by leveraging docker layer caching
-COPY go.mod go.sum vendor/ ./
 RUN mkdir -p bin
+RUN mkdir -p /go
 
 RUN dnf install -y --disableplugin=subscription-manager \
     --enablerepo=powertools \
     udica \
     golang make libsemanage-devel
 
-ADD . /work
+# NOTE(jaosorior): This allows us to use a specific golang version in CentOS as
+# opposed to the older one that comes with the distro.
+RUN go install golang.org/dl/${GO_VERSION}@latest
+RUN ${GO_VERSION} download
 
-RUN make
+COPY . /work
+
+RUN GO=${GO_VERSION} make
 
 FROM registry.centos.org/centos:8
 # TODO(jaosorior): Switch to UBI once we use static linking

--- a/images/Dockerfile.fedora
+++ b/images/Dockerfile.fedora
@@ -13,18 +13,25 @@
 # limitations under the License.
 
 FROM registry.fedoraproject.org/fedora-minimal:35 AS build
+ARG GO_VERSION=go1.17.3
+ENV GOPATH="/go"
+ENV PATH="$GOPATH/bin:$PATH"
 USER root
 WORKDIR /work
 
-# Speed up build by leveraging docker layer caching
-COPY go.mod go.sum vendor/ ./
 RUN mkdir -p bin
+RUN mkdir -p /go
 
 RUN microdnf install -y udica golang make libsemanage-devel
 
-ADD . /work
+# NOTE(jaosorior): This allows us to use a specific golang version in CentOS as
+# opposed to the older one that comes with the distro.
+RUN go install golang.org/dl/${GO_VERSION}@latest
+RUN ${GO_VERSION} download
 
-RUN make
+COPY . /work
+
+RUN GO=${GO_VERSION} make
 
 FROM registry.fedoraproject.org/fedora-minimal:35
 


### PR DESCRIPTION
This uses golang 1.17.3 for building the selinuxd images. to enable this, we also now allow overriding go command in Makefile.