### PR TITLE
profiling: Add support for handlers outside the pprof package

### DIFF
--- a/pkg/daemon/status_server.go
+++ b/pkg/daemon/status_server.go
@@ -99,6 +99,12 @@ func (ss *statusServer) initializeRoutes(r *mux.Router) {
 		r.HandleFunc("/debug/pprof/profile", pprof.Profile)
 		r.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 		r.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+		// Manually add support for paths linked to by index page at /debug/pprof/
+		r.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+		r.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+		r.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+		r.Handle("/debug/pprof/block", pprof.Handler("block"))
 	}
 }
 


### PR DESCRIPTION
The net/http/pprof package includes several ready-made hadlerFuncs that we
already use, but there are some, most notably heap that are not included
right away, but go through the Index() page handler and invoke
net/http/pprof.ServeHttp which then looks into the list of available
profiles in runtime/pprof, returns the raw data and lets ServeHttp
package them up in HTTP.

By calling the handlers by name, we can use them with our router over
UNIX socket, e.g.:
     curl --unix-socket /var/run/selinuxd/selinuxd.sock http://localhost/debug/pprof/heap --output - > /tmp/heap.selinuxd
