### PR TITLE
RIP CentOS

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -17,8 +17,8 @@ jobs:
         dockerfiles: |
           ./images/Dockerfile.fedora
 
-  build-centos:
-    name: Build CentOS image
+  build-almalinux:
+    name: Build Alma Linux image
     runs-on: ubuntu-20.04
 
     steps:
@@ -27,7 +27,7 @@ jobs:
     - name: Buildah Action
       uses: redhat-actions/buildah-build@v2
       with:
-        image: selinuxd-centos
+        image: selinuxd-almalinux
         tags: latest ${{ github.sha }}
         dockerfiles: |
-          ./images/Dockerfile.centos
+          ./images/Dockerfile.almalinux

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        centos: ["8"]
+        almalinux: ["8"]
     container:
-      image: centos:${{ matrix.centos }}
+      image: almalinux:${{ matrix.almalinux }}
     steps:
       - uses: actions/checkout@v2
       - name: install packages

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        base: ["fedora", "centos"]
+        base: ["fedora", "almalinux"]
     steps:
       - uses: actions/checkout@v2
       - run: make ${{ matrix.base }}-image
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 80
     strategy:
       matrix:
-        base: ["fedora", "centos"]
+        base: ["fedora", "almalinux"]
     env:
       RUN: ./hack/ci/run.sh
       IMG: quay.io/security-profiles-operator/selinuxd-${{ matrix.base }}:latest
@@ -84,7 +84,7 @@ jobs:
     timeout-minutes: 80
     strategy:
       matrix:
-        base: ["fedora", "centos"]
+        base: ["fedora", "almalinux"]
     env:
       RUN: ./hack/ci/run.sh
       IMG: quay.io/security-profiles-operator/selinuxd-${{ matrix.base }}:latest

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        centos: ["8"]
+        almalinux: ["8"]
     container:
-      image: centos:${{ matrix.centos }}
+      image: almalinux:${{ matrix.almalinux }}
     steps:
       - uses: actions/checkout@v2
       - name: install packages

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ IMAGE_TAG=latest
 IMAGE_REF=$(IMAGE_NAME):$(IMAGE_TAG)
 
 IMAGE_REPO?=quay.io/security-profiles-operator/$(IMAGE_REF)
-CENTOS_IMAGE_REPO?=quay.io/security-profiles-operator/$(IMAGE_NAME)-centos:$(IMAGE_TAG)
+ALMA_IMAGE_REPO?=quay.io/security-profiles-operator/$(IMAGE_NAME)-almalinux:$(IMAGE_TAG)
 FEDORA_IMAGE_REPO?=quay.io/security-profiles-operator/$(IMAGE_NAME)-fedora:$(IMAGE_TAG)
 
 TEST_OS?=fedora
@@ -90,15 +90,15 @@ $(GOPATH)/bin/golangci-lint:
 	GOLANGCI_LINT_CACHE=/tmp/golangci-cache $(GOPATH)/bin/golangci-lint linters
 
 .PHONY: image
-image: default-image centos-image fedora-image
+image: default-image almalinux-image fedora-image
 
 .PHONY: default-image
 default-image:
-	$(CONTAINER_RUNTIME) build -f images/Dockerfile.centos -t $(IMAGE_REPO) .
+	$(CONTAINER_RUNTIME) build -f images/Dockerfile.almalinux -t $(IMAGE_REPO) .
 
-.PHONY: centos-image
-centos-image:
-	$(CONTAINER_RUNTIME) build -f images/Dockerfile.centos -t $(CENTOS_IMAGE_REPO) .
+.PHONY: almalinux-image
+almalinux-image:
+	$(CONTAINER_RUNTIME) build -f images/Dockerfile.almalinux -t $(ALMA_IMAGE_REPO) .
 
 .PHONY: fedora-image
 fedora-image:

--- a/hack/ci/Vagrantfile-almalinux
+++ b/hack/ci/Vagrantfile-almalinux
@@ -3,7 +3,7 @@
 
 # Vagrant box for testing
 Vagrant.configure("2") do |config|
-  config.vm.box = "centos/8"
+  config.vm.box = "almalinux/8"
   memory = 6144
   cpus = 4
 
@@ -20,8 +20,8 @@ Vagrant.configure("2") do |config|
   config.vm.provision "set-env", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
       set -euxo pipefail
-      echo "export IMG='quay.io/security-profiles-operator/selinuxd-centos:latest'" >> /etc/profile.d/selinuxd-env.sh
-      echo "export OS='centos'" >> /etc/profile.d/selinuxd-env.sh
+      echo "export IMG='quay.io/security-profiles-operator/selinuxd-alma:latest'" >> /etc/profile.d/selinuxd-env.sh
+      echo "export OS='alma'" >> /etc/profile.d/selinuxd-env.sh
       echo "export CONTAINER_NAME='selinuxd'" >> /etc/profile.d/selinuxd-env.sh
     SHELL
   end

--- a/images/Dockerfile.almalinux
+++ b/images/Dockerfile.almalinux
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.centos.org/centos:8 AS build
+FROM docker.io/library/almalinux:8 AS build
 ARG GO_VERSION=go1.17.3
 ENV GOPATH="/go"
 ENV PATH="$GOPATH/bin:$PATH"
@@ -22,12 +22,12 @@ WORKDIR /work
 RUN mkdir -p bin
 RUN mkdir -p /go
 
-RUN dnf install -y --disableplugin=subscription-manager \
+RUN dnf install -y \
     --enablerepo=powertools \
     udica \
     golang make libsemanage-devel
 
-# NOTE(jaosorior): This allows us to use a specific golang version in CentOS as
+# NOTE(jaosorior): This allows us to use a specific golang version in Alma Linux as
 # opposed to the older one that comes with the distro.
 RUN go install golang.org/dl/${GO_VERSION}@latest
 RUN ${GO_VERSION} download
@@ -36,7 +36,7 @@ COPY . /work
 
 RUN GO=${GO_VERSION} make
 
-FROM registry.centos.org/centos:8
+FROM docker.io/library/almalinux:8
 # TODO(jaosorior): Switch to UBI once we use static linking
 #FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
@@ -47,7 +47,7 @@ LABEL name="selinuxd" \
       description="selinuxd is a daemon that listens for files in /etc/selinux.d/ and installs the relevant policies."
 
 # TODO(jaosorior): Remove once we use static linking
-RUN dnf install -y --disableplugin=subscription-manager \
+RUN dnf install -y \
     --enablerepo=powertools \
     policycoreutils
 

--- a/images/Dockerfile.fedora
+++ b/images/Dockerfile.fedora
@@ -24,7 +24,7 @@ RUN mkdir -p /go
 
 RUN microdnf install -y udica golang make libsemanage-devel
 
-# NOTE(jaosorior): This allows us to use a specific golang version in CentOS as
+# NOTE(jaosorior): This allows us to use a specific golang version in Fedora as
 # opposed to the older one that comes with the distro.
 RUN go install golang.org/dl/${GO_VERSION}@latest
 RUN ${GO_VERSION} download


### PR DESCRIPTION
CentOS 8 went EOL by the end of 2021. Let's use Alma Linux instead while
we're waiting for UBI to be actually useful.

Signed-off-by: Jakub Hrozek <jakub.hrozek@redhat.com>
