### PR TITLE
Don't install udica just to get the policy templates

### DIFF
--- a/images/Dockerfile.centos
+++ b/images/Dockerfile.centos
@@ -24,7 +24,7 @@ RUN mkdir -p /go
 
 RUN dnf install -y \
     --enablerepo=powertools \
-    udica \
+    container-selinux \
     golang make libsemanage-devel
 
 # NOTE(jaosorior): This allows us to use a specific golang version in CentOS as

--- a/images/Dockerfile.centos
+++ b/images/Dockerfile.centos
@@ -53,11 +53,6 @@ RUN dnf install -y \
 
 RUN mkdir -p /usr/share/selinuxd/templates
 COPY --from=build /usr/share/udica/templates/* /usr/share/selinuxd/templates/
-
-# For backwards compatibility with older SPO, we can remove later
-RUN mkdir -p /usr/share/udica/
-RUN ln -s /usr/share/selinuxd/templates /usr/share/udica/templates
-
 COPY --from=build /work/bin/selinuxdctl /usr/bin/
 
 ENTRYPOINT ["/usr/bin/selinuxdctl"]

--- a/images/Dockerfile.fedora
+++ b/images/Dockerfile.fedora
@@ -22,7 +22,7 @@ WORKDIR /work
 RUN mkdir -p bin
 RUN mkdir -p /go
 
-RUN microdnf install -y udica golang make libsemanage-devel
+RUN microdnf install -y golang make libsemanage-devel container-selinux
 
 # NOTE(jaosorior): This allows us to use a specific golang version in CentOS as
 # opposed to the older one that comes with the distro.

--- a/images/Dockerfile.fedora
+++ b/images/Dockerfile.fedora
@@ -46,12 +46,6 @@ RUN microdnf install -y policycoreutils
 
 RUN mkdir -p /usr/share/selinuxd/templates
 COPY --from=build /usr/share/udica/templates/* /usr/share/selinuxd/templates/
-
-# For backwards compatibility with older SPO, we can remove later
-RUN mkdir -p /usr/share/udica/
-RUN ln -s /usr/share/selinuxd/templates /usr/share/udica/templates
-
-
 COPY --from=build /work/bin/selinuxdctl /usr/bin/
 
 ENTRYPOINT ["/usr/bin/selinuxdctl"]


### PR DESCRIPTION
- images: Install container-selinux instead of udica
- images: Remove backwards compatible directories

It appears that the udica templates have been moved to container-selinux,
which means we no longer have to install the udica package just to get
the templates.

Also removes some old compat directories that are no longer needed.
