### PR TITLE
make: Save the proper image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ push:
 
 image.tar:
 	$(MAKE) $(TEST_OS)-image && \
-	$(CONTAINER_RUNTIME) save -o image.tar $(FEDORA_IMAGE_REPO); \
+	$(CONTAINER_RUNTIME) save -o image.tar quay.io/security-profiles-operator/$(IMAGE_NAME)-$(TEST_OS):$(IMAGE_TAG); \
 
 .PHONY: vagrant-up
 vagrant-up: image.tar ## Boot the vagrant based test VM


### PR DESCRIPTION
The image.tar Makefile target was always saving the fedora image, even
when TEST_OS was set to CentOS/Alma/whatever.

Signed-off-by: Jakub Hrozek <jhrozek@redhat.com>
