### PR TITLE
hack: Install oci-seccomp-bpf on RHEL-like systems

### DIFF
--- a/hack/ci/Vagrantfile-centos
+++ b/hack/ci/Vagrantfile-centos
@@ -35,6 +35,7 @@ Vagrant.configure("2") do |config|
         golang \
         podman \
         container-selinux \
+        oci-seccomp-bpf-hook \
         udica
     SHELL
   end


### PR DESCRIPTION
This allows to record seccomp policies on CentOS systems.
