### PR TITLE
hack: Remove unneeded workaround

### DIFF
--- a/hack/ci/daemon-and-trace.sh
+++ b/hack/ci/daemon-and-trace.sh
@@ -19,10 +19,6 @@ source /etc/profile.d/selinuxd-env.sh
 
 mkdir -p /etc/selinux.d
 
-sed -e '/RefuseManualStop/ s/^#*/#/' -i /usr/lib/systemd/system/auditd.service
-systemctl daemon-reload
-systemctl stop auditd
-
 # Initialize base policies
 podman run \
     --name policy-copy \


### PR DESCRIPTION
This hack was needed to work around a container-selinux bug which was
fixed in the meantime. Let's remove cruft from our tests.
