### PR TITLE
Use priority 350 for selinuxd modules

### DIFF
--- a/pkg/semodule/policycoreutils/policycoreutils.go
+++ b/pkg/semodule/policycoreutils/policycoreutils.go
@@ -36,7 +36,7 @@ func (smt *SEModulePcuHandler) SetAutoCommit(_ bool) {
 }
 
 func (smt *SEModulePcuHandler) Install(modulePath string) error {
-	out, err := runSemodule("-i", modulePath)
+	out, err := runSemodule("-X", "350", "-i", modulePath)
 	if err != nil {
 		smt.logger.Error(err, "Installing policy", "modulePath", modulePath)
 		return seiface.NewErrCannotInstallModule(modulePath)
@@ -47,16 +47,23 @@ func (smt *SEModulePcuHandler) Install(modulePath string) error {
 }
 
 func (smt *SEModulePcuHandler) List() ([]string, error) {
-	out, err := runSemodule("-l")
+	out, err := runSemodule("-lfull")
 	if err != nil {
 		smt.logger.Error(err, "Listing policies")
 		return nil, seiface.ErrList
 	}
-	return strings.Split(string(out), "\n"), nil
+	modules := make([]string, 0)
+	for _, line := range strings.Split(string(out), "\n") {
+		module := strings.Split(line, " ")
+		if module[0] == "350" {
+			modules = append(modules, module[1])
+		}
+	}
+	return modules, nil
 }
 
 func (smt *SEModulePcuHandler) Remove(modToRemove string) error {
-	out, err := runSemodule("-r", modToRemove)
+	out, err := runSemodule("-X", "350", "-r", modToRemove)
 	if err != nil {
 		smt.logger.Error(err, "Removing a policy", "modToRemove", modToRemove)
 		return seiface.NewErrCannotRemoveModule(modToRemove)


### PR DESCRIPTION
SELinux modules store has a concept of priorities which can be used for
detection of the source of modules:

    # semodule -lfull
    400 agent-udica       cil
    200 cockpit           pp
    200 container         pp
    ...
    100 abrt              pp
    100 accountsd         pp
    ...

In Red Hat Enterprise Linux and Fedora we use priority 100 for modules
from selinux-policy-targeted package, 200 is used for modules from
packages shipping their own policies, 300 is suggested by
SETroubleshoot, and 400 is the default for user modules.

Priority 350 for selinuxd modules was suggested by SELinux team.

Signed-off-by: Petr Lautrbach <plautrba@redhat.com>