### PR TITLE
Print deamon info on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PROJECT=selinuxd
 BIN=$(BINDIR)/selinuxdctl
 BINDIR=bin
 POLICYDIR=/etc/selinux.d
@@ -5,6 +6,8 @@ POLICYDIR=/etc/selinux.d
 SRC=$(shell find . -name "*.go")
 
 GO?=go
+
+GO_PROJECT := github.com/containers/$(PROJECT)
 
 # External Helper variables
 
@@ -17,7 +20,7 @@ GOLANGCI_LINT_URL=https://github.com/golangci/golangci-lint/releases/download/v$
 
 CONTAINER_RUNTIME?=podman
 
-IMAGE_NAME=selinuxd
+IMAGE_NAME=$(PROJECT)
 IMAGE_TAG=latest
 
 IMAGE_REF=$(IMAGE_NAME):$(IMAGE_TAG)
@@ -27,6 +30,20 @@ CENTOS_IMAGE_REPO?=quay.io/security-profiles-operator/$(IMAGE_NAME)-centos:$(IMA
 FEDORA_IMAGE_REPO?=quay.io/security-profiles-operator/$(IMAGE_NAME)-fedora:$(IMAGE_TAG)
 
 TEST_OS?=fedora
+
+DATE_FMT = +'%Y-%m-%dT%H:%M:%SZ'
+BUILD_DATE ?= $(shell date -u "$(DATE_FMT)")
+
+# By default the version is the latest tag in the current branch,
+# if there is none, then the commit hash
+VERSION := $(shell git describe --tag)
+ifeq ($(VERSION),)
+	VERSION := $(shell git rev-parse --short --verify HEAD)
+endif
+
+LDVARS := \
+	-X $(GO_PROJECT)/pkg/version.buildDate=$(BUILD_DATE) \
+	-X $(GO_PROJECT)/pkg/version.version=$(VERSION)
 
 SEMODULE_BACKEND?=policycoreutils
 ifeq ($(SEMODULE_BACKEND), semanage)
@@ -45,11 +62,11 @@ all: build
 build: $(BIN)
 
 $(BIN): $(BINDIR) $(SRC) pkg/semodule/semanage/callbacks.c
-	$(GO) build -tags '$(BUILDTAGS)' -o $(BIN) .
+	$(GO) build -ldflags "$(LDVARS)" -tags '$(BUILDTAGS)' -o $(BIN) .
 
 .PHONY: test
 test:
-	$(GO) test -tags '$(BUILDTAGS)' -race github.com/containers/selinuxd/pkg/...
+	$(GO) test -tags '$(BUILDTAGS)' -race $(GO_PROJECT)/pkg/...
 
 .PHONY: e2e
 e2e:

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containers/selinuxd/pkg/daemon"
 	"github.com/containers/selinuxd/pkg/datastore"
 	"github.com/containers/selinuxd/pkg/semodule"
+	"github.com/containers/selinuxd/pkg/version"
 )
 
 // daemonCmd represents the daemon command
@@ -99,6 +100,8 @@ func daemonCmdFunc(rootCmd *cobra.Command, _ []string) {
 		logger.Error(err, "Parsing flags")
 		syscall.Exit(1)
 	}
+
+	version.PrintInfoPermissive(logger)
 
 	exitSignal := make(chan os.Signal, 1)
 	done := make(chan bool)

--- a/cmd/oneshot.go
+++ b/cmd/oneshot.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containers/selinuxd/pkg/datastore"
 	"github.com/containers/selinuxd/pkg/semodule"
 	seiface "github.com/containers/selinuxd/pkg/semodule/interface"
+	"github.com/containers/selinuxd/pkg/version"
 )
 
 // oneshotCmd represents the oneshot command
@@ -78,6 +79,8 @@ func oneshotCmdFunc(rootCmd *cobra.Command, _ []string) {
 		fmt.Fprintf(os.Stderr, "%s", err)
 		syscall.Exit(1)
 	}
+
+	version.PrintInfoPermissive(logger)
 
 	opts, err := parseOneShotFlags(rootCmd)
 	if err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,50 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/go-logr/logr"
+)
+
+var (
+	buildDate string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	version   string // the current version of the daemon
+)
+
+type Info struct {
+	Version   string `json:"version,omitempty"`
+	BuildDate string `json:"buildDate,omitempty"`
+	Compiler  string `json:"compiler,omitempty"`
+	Platform  string `json:"platform,omitempty"`
+}
+
+// AsKeyValues returns a key value slice of the info.
+func (i *Info) AsKeyValues() []interface{} {
+	return []interface{}{
+		"version", i.Version,
+		"buildDate", i.BuildDate,
+		"compiler", i.Compiler,
+		"platform", i.Platform,
+	}
+}
+
+func getInfo() *Info {
+	return &Info{
+		Version:   version,
+		BuildDate: buildDate,
+		Compiler:  runtime.Compiler,
+		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+func printInfo(logger logr.Logger, info *Info) {
+	logger.Info(
+		"selinuxd information",
+		info.AsKeyValues()...,
+	)
+}
+
+func PrintInfoPermissive(logger logr.Logger) {
+	printInfo(logger, getInfo())
+}


### PR DESCRIPTION
Sets the tag from the latest tag as a string during build and prints that
version along with other information during the daemon and oneshot commands
so that operator using selinuxd as an operand can know what exact selinuxd
version was being used.

Signed-off-by: Jakub Hrozek <jhrozek@redhat.com>
