### PR TITLE
Improve logging from policycoreutils utilities

### DIFF
--- a/pkg/semodule/policycoreutils/policycoreutils.go
+++ b/pkg/semodule/policycoreutils/policycoreutils.go
@@ -20,7 +20,7 @@ type SEModulePcuHandler struct {
 var _ seiface.Handler = &SEModulePcuHandler{}
 
 func runSemodule(opFlag string, policyArgs ...string) (string, error) {
-	fullArgs := []string{"-v", opFlag}
+	fullArgs := []string{opFlag}
 	fullArgs = append(fullArgs, policyArgs...)
 	cmd := exec.CommandContext(context.TODO(), "/usr/sbin/semodule", fullArgs...)
 	out, err := cmd.CombinedOutput()
@@ -38,11 +38,11 @@ func (smt *SEModulePcuHandler) SetAutoCommit(_ bool) {
 func (smt *SEModulePcuHandler) Install(modulePath string) error {
 	out, err := runSemodule("-X", "350", "-i", modulePath)
 	if err != nil {
-		smt.logger.Error(err, "Installing policy", "modulePath", modulePath)
+		smt.logger.Error(err, "Installing policy", "modulePath", modulePath, "output", out)
 		return seiface.NewErrCannotInstallModule(modulePath)
 	}
 
-	smt.logger.Info("Installing policy", "modulePath", modulePath, "out", out)
+	smt.logger.Info("Installing policy", "modulePath", modulePath, "output", out)
 	return nil
 }
 
@@ -65,11 +65,11 @@ func (smt *SEModulePcuHandler) List() ([]string, error) {
 func (smt *SEModulePcuHandler) Remove(modToRemove string) error {
 	out, err := runSemodule("-X", "350", "-r", modToRemove)
 	if err != nil {
-		smt.logger.Error(err, "Removing a policy", "modToRemove", modToRemove)
+		smt.logger.Error(err, "Removing a policy", "modToRemove", modToRemove, "output", out)
 		return seiface.NewErrCannotRemoveModule(modToRemove)
 	}
 
-	smt.logger.Info("Removing a policy", "out", out)
+	smt.logger.Info("Removing a policy", "output", out)
 	return nil
 }
 


### PR DESCRIPTION
- provide output from semodule in error messages

It might be useful to provide error semodule message, e.g.

{"level":"error","ts":1652443238.6348724,"caller":"policycoreutils/policycoreutils.go:41","msg":"Installing policy","modulePath":"/etc/selinux.d/wrongmodule.cil","output":"Re-declaration of typealias auditadm_ssh_tmpfs_t\nPrevious declaration of typealias at /var/lib/selinux/targeted/tmp/modules/350/wrongmodule/cil:1\nBad typealias declaration at /var/lib/selinux/targeted/tmp/modules/350/wrongmodule/cil:1\nFailed to build AST\n/usr/sbin/semodule:  Failed!\n","stacktrace":"github.com/containers/selinuxd/pkg/semodule/policycoreutils.(*SEModulePcuHandler).Install\n\t/home/plautrba/devel/src/selinuxd/pkg/semodule/policycoreutils/policycoreutils.go:41\ngithub.com/containers/selinuxd/pkg/daemon.(*policyInstall).do\n\t/home/plautrba/devel/src/selinuxd/pkg/daemon/action.go:52\ngithub.com/containers/selinuxd/pkg/daemon.InstallPolicies\n\t/home/plautrba/devel/src/selinuxd/pkg/daemon/daemon.go:124"}

- drop semodule -v option

It provides unnecessary noise

- rename out key to output and make it consistent with daemon.go

Signed-off-by: Petr Lautrbach <plautrba@redhat.com>