### PR TITLE
Bump golangci-lint, fix lint issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GO_PROJECT := github.com/containers/$(PROJECT)
 
 # External Helper variables
 
-GOLANGCI_LINT_VERSION=1.33.0
+GOLANGCI_LINT_VERSION=1.50.1
 GOLANGCI_LINT_OS=linux
 ifeq ($(OS_NAME), Darwin)
     GOLANGCI_LINT_OS=darwin

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -41,7 +41,7 @@ func getLogger() (logr.Logger, error) {
 	logIf := zapr.NewLogger(logger)
 	// NOTE(jaosorior): While this may return errors, they're mostly
 	// harmless and handling them is more work than its worth
-	// nolint:errcheck
+	//nolint:errcheck
 	defer logger.Sync() // flushes buffer, if any
 	return logIf, nil
 }
@@ -50,7 +50,11 @@ func getHTTPClient(sockpath string) *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", sockpath)
+				conn, err := net.Dial("unix", sockpath)
+				if err != nil {
+					return nil, fmt.Errorf("error dialing unix socket: %w", err)
+				}
+				return conn, nil
 			},
 		},
 	}

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,12 +21,11 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/spf13/cobra"
-
 	"github.com/containers/selinuxd/pkg/daemon"
 	"github.com/containers/selinuxd/pkg/datastore"
 	"github.com/containers/selinuxd/pkg/semodule"
 	"github.com/containers/selinuxd/pkg/version"
+	"github.com/spf13/cobra"
 )
 
 // daemonCmd represents the daemon command
@@ -42,7 +41,7 @@ to quickly create a Cobra application.`,
 	Run: daemonCmdFunc,
 }
 
-// nolint:gochecknoinits
+//nolint:gochecknoinits
 func init() {
 	rootCmd.AddCommand(daemonCmd)
 	defineFlags(daemonCmd)

--- a/cmd/is-ready.go
+++ b/cmd/is-ready.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,9 +23,8 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/spf13/cobra"
-
 	"github.com/containers/selinuxd/pkg/daemon"
+	"github.com/spf13/cobra"
 )
 
 // isreadyCmd represents the is-ready command
@@ -36,7 +35,7 @@ var isreadyCmd = &cobra.Command{
 	Run:   isreadyCmdFunc,
 }
 
-// nolint:gochecknoinits
+//nolint:gochecknoinits
 func init() {
 	rootCmd.AddCommand(isreadyCmd)
 	defineIsReadyFlags(isreadyCmd)

--- a/cmd/oneshot.go
+++ b/cmd/oneshot.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,14 +20,13 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/go-logr/logr"
-	"github.com/spf13/cobra"
-
 	"github.com/containers/selinuxd/pkg/daemon"
 	"github.com/containers/selinuxd/pkg/datastore"
 	"github.com/containers/selinuxd/pkg/semodule"
 	seiface "github.com/containers/selinuxd/pkg/semodule/interface"
 	"github.com/containers/selinuxd/pkg/version"
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
 )
 
 // oneshotCmd represents the oneshot command
@@ -38,7 +37,7 @@ var oneshotCmd = &cobra.Command{
 	Run:   oneshotCmdFunc,
 }
 
-// nolint:gochecknoinits
+//nolint:gochecknoinits
 func init() {
 	rootCmd.AddCommand(oneshotCmd)
 	defineOneShotFlags(oneshotCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -50,7 +50,7 @@ func Execute() {
 	}
 }
 
-// nolint:gochecknoinits
+//nolint:gochecknoinits
 func init() {
 	cobra.OnInitialize(initConfig)
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,10 +26,9 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containers/selinuxd/pkg/daemon"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
-
-	"github.com/containers/selinuxd/pkg/daemon"
 )
 
 // statusCmd represents the status command
@@ -41,7 +40,7 @@ var statusCmd = &cobra.Command{
 	Run:   statusCmdFunc,
 }
 
-// nolint:gochecknoinits
+//nolint:gochecknoinits
 func init() {
 	rootCmd.AddCommand(statusCmd)
 	defineStatusFlags(statusCmd)

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -14,11 +14,10 @@ import (
 	"time"
 
 	backoff "github.com/cenkalti/backoff/v4"
-	"github.com/go-logr/zapr"
-	"go.uber.org/zap"
-
 	"github.com/containers/selinuxd/pkg/datastore"
 	"github.com/containers/selinuxd/pkg/semodule/test"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
 )
 
 const (
@@ -40,7 +39,7 @@ func getPolicyPath(module, path string) string {
 func installPolicy(module, path string, t *testing.T) {
 	modPath := getPolicyPath(module, path)
 	message := []byte("Hello, Gophers!")
-	err := ioutil.WriteFile(modPath, message, 0600)
+	err := ioutil.WriteFile(modPath, message, 0o600)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,6 +58,7 @@ func getHTTPClient(sockpath string) *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				//nolint: wrapcheck // let's not complicate the test
 				return net.Dial("unix", sockpath)
 			},
 		},
@@ -73,7 +73,7 @@ func getReadyRequest(ctx context.Context, t *testing.T) *http.Request {
 	return req
 }
 
-// nolint:gocognit,gocyclo
+//nolint:gocognit,gocyclo
 func TestDaemon(t *testing.T) {
 	done := make(chan bool)
 	logger, err := zap.NewDevelopment()
@@ -294,7 +294,7 @@ func TestDaemon(t *testing.T) {
 		}
 
 		perms := fi.Mode().Perm()
-		if perms != 0660 {
+		if perms != 0o660 {
 			t.Fatalf("wrong perms, got %#o expected 0660", perms)
 		}
 
@@ -315,7 +315,7 @@ func TestDaemon(t *testing.T) {
 	subdirPolicy := "subdirpolicy"
 
 	t.Run("Module should track a policy in sub-directory", func(t *testing.T) {
-		if err := os.Mkdir(subdirPath, 0700); err != nil {
+		if err := os.Mkdir(subdirPath, 0o700); err != nil {
 			t.Fatalf("Unable to create sub-directory: %s", err)
 		}
 		installPolicy(subdirPolicy, subdirPath, t)
@@ -390,7 +390,7 @@ func TestDaemonWithSubdir(t *testing.T) {
 	subdirPolicy := "subdirpolicy"
 
 	t.Run("Install policy before daemon runs", func(t *testing.T) {
-		if err := os.Mkdir(subdirPath, 0700); err != nil {
+		if err := os.Mkdir(subdirPath, 0o700); err != nil {
 			t.Fatalf("Unable to create sub-directory: %s", err)
 		}
 		installPolicy(subdirPolicy, subdirPath, t)

--- a/pkg/daemon/status_server.go
+++ b/pkg/daemon/status_server.go
@@ -8,16 +8,17 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
-
-	"github.com/go-logr/logr"
-	"github.com/gorilla/mux"
+	"time"
 
 	"github.com/containers/selinuxd/pkg/datastore"
+	"github.com/go-logr/logr"
+	"github.com/gorilla/mux"
 )
 
 const (
 	DefaultUnixSockAddr = "/var/run/selinuxd.sock"
-	unixSockMode        = 0660
+	unixSockMode        = 0o660
+	readTimeout         = 5 * time.Second
 )
 
 type StatusServerConfig struct {
@@ -56,7 +57,8 @@ func (ss *statusServer) Serve(readychan <-chan bool) error {
 	ss.initializeRoutes(r)
 
 	server := &http.Server{
-		Handler: r,
+		Handler:     r,
+		ReadTimeout: readTimeout,
 	}
 
 	go ss.waitForReady(readychan)

--- a/pkg/datastore/test.go
+++ b/pkg/datastore/test.go
@@ -25,11 +25,13 @@ func NewTestCountedDS(path string) (*TestCountedDS, error) {
 }
 
 func (tcds *TestCountedDS) Close() error {
+	//nolint:wrapcheck // let's not complicate the test code
 	return tcds.ds.Close()
 }
 
 func (tcds *TestCountedDS) Get(policy string) (PolicyStatus, error) {
 	atomic.AddInt32(&tcds.getCounter, 1)
+	//nolint:wrapcheck // let's not complicate the test code
 	return tcds.ds.Get(policy)
 }
 
@@ -38,11 +40,13 @@ func (tcds *TestCountedDS) GetCalls() int32 {
 }
 
 func (tcds *TestCountedDS) List() ([]string, error) {
+	//nolint:wrapcheck // let's not complicate the test code
 	return tcds.ds.List()
 }
 
 func (tcds *TestCountedDS) Put(status PolicyStatus) error {
 	atomic.AddInt32(&tcds.putCounter, 1)
+	//nolint:wrapcheck // let's not complicate the test code
 	return tcds.ds.Put(status)
 }
 
@@ -51,6 +55,7 @@ func (tcds *TestCountedDS) PutCalls() int32 {
 }
 
 func (tcds *TestCountedDS) Remove(policy string) error {
+	//nolint:wrapcheck // let's not complicate the test code
 	return tcds.ds.Remove(policy)
 }
 

--- a/pkg/semodule/semodule_fallback.go
+++ b/pkg/semodule/semodule_fallback.go
@@ -6,9 +6,8 @@ package semodule
 import (
 	"errors"
 
-	"github.com/go-logr/logr"
-
 	seiface "github.com/containers/selinuxd/pkg/semodule/interface"
+	"github.com/go-logr/logr"
 )
 
 // ErrNoSemodule is an error when no usable semodule back end is selected

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -5,10 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/containers/selinuxd/pkg/datastore"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/containers/selinuxd/pkg/datastore"
 )
 
 var _ = Describe("E2e", func() {
@@ -86,7 +85,7 @@ var _ = Describe("E2e", func() {
 			)
 			BeforeEach(func() {
 				By("Creating subdir")
-				mkdirErr := os.Mkdir(subdirPath, 0700)
+				mkdirErr := os.Mkdir(subdirPath, 0o700)
 				Expect(mkdirErr).ToNot(HaveOccurred())
 				installPolicyFromReference("../data/testport.cil", policyPath)
 			})

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -10,7 +10,6 @@ import (
 
 	//nolint:golint,stylecheck
 	. "github.com/onsi/ginkgo/v2"
-
 	//nolint:golint,stylecheck
 	. "github.com/onsi/gomega"
 )


### PR DESCRIPTION
- bump golang-ci version
- Fix lint issues

This is probably useful on its own, but some dep bump PRs like #68 and #71
were failing on the linting step and I suspect it's because our linter is
so out of date that it starts to have issues with modern code.
