### PR TITLE
Use go 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/selinuxd
 
-go 1.18
+go 1.19
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.3

--- a/images/Dockerfile.centos
+++ b/images/Dockerfile.centos
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM docker.io/almalinux:8 AS build
-ARG GO_VERSION=go1.18.6
+ARG GO_VERSION=go1.19.3
 ENV GOPATH="/go"
 ENV PATH="$GOPATH/bin:$PATH"
 USER root

--- a/images/Dockerfile.fedora
+++ b/images/Dockerfile.fedora
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM registry.fedoraproject.org/fedora-minimal:36 AS build
-ARG GO_VERSION=go1.18.6
+ARG GO_VERSION=go1.19.3
 ENV GOPATH="/go"
 ENV PATH="$GOPATH/bin:$PATH"
 USER root


### PR DESCRIPTION
Downstream has finally put its act together and has a 1.19 builder, so
I'm bumping the upstream version as well.

I did also ran go mod tidy and go mod vendor, but that produces no diff.
