### PR TITLE
Bump test libraries, fix lint issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.4.0
-	github.com/onsi/gomega v1.22.1
+	github.com/onsi/gomega v1.24.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0
 	go.etcd.io/bbolt v1.3.6

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/onsi/ginkgo/v2 v2.4.0
+	github.com/onsi/ginkgo/v2 v2.5.0
 	github.com/onsi/gomega v1.24.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.4.0 h1:+Ig9nvqgS5OBSACXNk15PLdp0U9XPYROt9CFzVdFGIs=
 github.com/onsi/ginkgo/v2 v2.4.0/go.mod h1:iHkDK1fKGcBoEHT5W7YBq4RFWaQulw+caOMkAt4OrFo=
-github.com/onsi/gomega v1.22.1 h1:pY8O4lBfsHKZHM/6nrxkhVPUznOlIu3quZcKP/M20KI=
-github.com/onsi/gomega v1.22.1/go.mod h1:x6n7VNe4hw0vkyYUM4mjIXx3JbLiPaBPNgB7PRQ1tuM=
+github.com/onsi/gomega v1.24.0 h1:+0glovB9Jd6z3VR+ScSwQqXVTIfJcGA9UBM8yzQxhqg=
+github.com/onsi/gomega v1.24.0/go.mod h1:Z/NWtiqwBrwUt4/2loMmHL63EDLnYHmVbuBpDr2vQAg=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.5 h1:ipoSadvV8oGUjnUbMub59IDPPwfxF694nG/jwbMiyQg=

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/onsi/ginkgo/v2 v2.4.0 h1:+Ig9nvqgS5OBSACXNk15PLdp0U9XPYROt9CFzVdFGIs=
-github.com/onsi/ginkgo/v2 v2.4.0/go.mod h1:iHkDK1fKGcBoEHT5W7YBq4RFWaQulw+caOMkAt4OrFo=
+github.com/onsi/ginkgo/v2 v2.5.0 h1:TRtrvv2vdQqzkwrQ1ke6vtXf7IK34RBUJafIy1wMwls=
+github.com/onsi/ginkgo/v2 v2.5.0/go.mod h1:Luc4sArBICYCS8THh8v3i3i5CuSZO+RaQRaJoeNwomw=
 github.com/onsi/gomega v1.24.0 h1:+0glovB9Jd6z3VR+ScSwQqXVTIfJcGA9UBM8yzQxhqg=
 github.com/onsi/gomega v1.24.0/go.mod h1:Z/NWtiqwBrwUt4/2loMmHL63EDLnYHmVbuBpDr2vQAg=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -39,7 +38,7 @@ func getPolicyPath(module, path string) string {
 func installPolicy(module, path string, t *testing.T) {
 	modPath := getPolicyPath(module, path)
 	message := []byte("Hello, Gophers!")
-	err := ioutil.WriteFile(modPath, message, 0o600)
+	err := os.WriteFile(modPath, message, 0o600)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,13 +80,13 @@ func TestDaemon(t *testing.T) {
 		t.Fatalf("Couldn't initialize logger: %s", err)
 	}
 
-	moddir, err := ioutil.TempDir("", "semodtest")
+	moddir, err := os.MkdirTemp("", "semodtest")
 	if err != nil {
 		t.Fatalf("Error creating temporary directory: %s", err)
 	}
 	defer os.RemoveAll(moddir) // clean up
 
-	dir, err := ioutil.TempDir("", "selinuxd")
+	dir, err := os.MkdirTemp("", "selinuxd")
 	if err != nil {
 		t.Fatalf("Error creating temporary directory: %s", err)
 	}
@@ -355,13 +354,13 @@ func TestDaemonWithSubdir(t *testing.T) {
 		t.Fatalf("Couldn't initialize logger: %s", err)
 	}
 
-	moddir, err := ioutil.TempDir("", "semodtest")
+	moddir, err := os.MkdirTemp("", "semodtest")
 	if err != nil {
 		t.Fatalf("Error creating temporary directory: %s", err)
 	}
 	defer os.RemoveAll(moddir) // clean up
 
-	dir, err := ioutil.TempDir("", "selinuxd")
+	dir, err := os.MkdirTemp("", "selinuxd")
 	if err != nil {
 		t.Fatalf("Error creating temporary directory: %s", err)
 	}

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -1,14 +1,13 @@
 package datastore
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func getNewStorePath(t *testing.T) (dspath string, cleanup func()) {
-	d, err := ioutil.TempDir("", "store")
+	d, err := os.MkdirTemp("", "store")
 	if err != nil {
 		t.Fatalf("Couldn't create tmpfile")
 	}
@@ -41,7 +40,7 @@ func TestDataStore(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var path string
 			if tt.generateTmpDir {
-				d, err := ioutil.TempDir("", "store")
+				d, err := os.MkdirTemp("", "store")
 				if err != nil {
 					t.Errorf("Couldn't create tmpfile")
 					return

--- a/vendor/github.com/onsi/ginkgo/v2/CHANGELOG.md
+++ b/vendor/github.com/onsi/ginkgo/v2/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 2.5.0
+
+### Ginkgo output now includes a timeline-view of the spec
+
+This commit changes Ginkgo's default output.  Spec details are now
+presented as a **timeline** that includes events that occur during the spec
+lifecycle interleaved with any GinkgoWriter content.  This makes is much easier
+to understand the flow of a spec and where a given failure occurs.
+
+The --progress, --slow-spec-threshold, --always-emit-ginkgo-writer flags
+and the SuppressProgressReporting decorator have all been deprecated.  Instead
+the existing -v and -vv flags better capture the level of verbosity to display.  However,
+a new --show-node-events flag is added to include node `> Enter` and `< Exit` events
+in the spec timeline.
+
+In addition, JUnit reports now include the timeline (rendered with -vv) and custom JUnit
+reports can be configured and generated using
+`GenerateJUnitReportWithConfig(report types.Report, dst string, config JunitReportConfig)`
+
+Code should continue to work unchanged with this version of Ginkgo - however if you have tooling that
+was relying on the specific output format of Ginkgo you _may_ run into issues.  Ginkgo's console output is not guaranteed to be stable for tooling and automation purposes.  You should, instead, use Ginkgo's JSON format
+to build tooling on top of as it has stronger guarantees to be stable from version to version.
+
+### Features
+- Provide details about which timeout expired [0f2fa27]
+
+### Fixes
+- Add Support Policy to docs [c70867a]
+
+### Maintenance
+- Bump github.com/onsi/gomega from 1.22.1 to 1.23.0 (#1070) [bb3b4e2]
+
 ## 2.4.0
 
 ### Features

--- a/vendor/github.com/onsi/ginkgo/v2/README.md
+++ b/vendor/github.com/onsi/ginkgo/v2/README.md
@@ -4,11 +4,7 @@
 
 ---
 
-# Ginkgo 2.0 is now Generally Available!
-
-You can learn more about 2.0 in the [Migration Guide](https://onsi.github.io/ginkgo/MIGRATING_TO_V2)!
-
----
+# Ginkgo
 
 Ginkgo is a mature testing framework for Go designed to help you write expressive specs.  Ginkgo builds on top of Go's `testing` foundation and is complemented by the [Gomega](https://github.com/onsi/gomega) matcher library.  Together, Ginkgo and Gomega let you express the intent behind your specs clearly:
 
@@ -33,53 +29,53 @@ Describe("Checking books out of the library", Label("library"), func() {
     })
 
     When("the library has the book in question", func() {
-        BeforeEach(func() {
-            Expect(library.Store(book)).To(Succeed())
+        BeforeEach(func(ctx SpecContext) {
+            Expect(library.Store(ctx, book)).To(Succeed())
         })
 
         Context("and the book is available", func() {
-            It("lends it to the reader", func() {
-                Expect(valjean.Checkout(library, "Les Miserables")).To(Succeed())
+            It("lends it to the reader", func(ctx SpecContext) {
+                Expect(valjean.Checkout(ctx, library, "Les Miserables")).To(Succeed())
                 Expect(valjean.Books()).To(ContainElement(book))
-                Expect(library.UserWithBook(book)).To(Equal(valjean))
-            })
+                Expect(library.UserWithBook(ctx, book)).To(Equal(valjean))
+            }, SpecTimeout(time.Second * 5))
         })
 
         Context("but the book has already been checked out", func() {
             var javert *users.User
-            BeforeEach(func() {
+            BeforeEach(func(ctx SpecContext) {
                 javert = users.NewUser("Javert")
-                Expect(javert.Checkout(library, "Les Miserables")).To(Succeed())
+                Expect(javert.Checkout(ctx, library, "Les Miserables")).To(Succeed())
             })
 
-            It("tells the user", func() {
-                err := valjean.Checkout(library, "Les Miserables")
+            It("tells the user", func(ctx SpecContext) {
+                err := valjean.Checkout(ctx, library, "Les Miserables")
                 Expect(error).To(MatchError("Les Miserables is currently checked out"))
-            })
+            }, SpecTimeout(time.Second * 5))
 
-            It("lets the user place a hold and get notified later", func() {
-                Expect(valjean.Hold(library, "Les Miserables")).To(Succeed())
-                Expect(valjean.Holds()).To(ContainElement(book))
+            It("lets the user place a hold and get notified later", func(ctx SpecContext) {
+                Expect(valjean.Hold(ctx, library, "Les Miserables")).To(Succeed())
+                Expect(valjean.Holds(ctx)).To(ContainElement(book))
 
                 By("when Javert returns the book")
-                Expect(javert.Return(library, book)).To(Succeed())
+                Expect(javert.Return(ctx, library, book)).To(Succeed())
 
                 By("it eventually informs Valjean")
                 notification := "Les Miserables is ready for pick up"
-                Eventually(valjean.Notifications).Should(ContainElement(notification))
+                Eventually(ctx, valjean.Notifications).Should(ContainElement(notification))
 
-                Expect(valjean.Checkout(library, "Les Miserables")).To(Succeed())
-                Expect(valjean.Books()).To(ContainElement(book))
-                Expect(valjean.Holds()).To(BeEmpty())
-            })
+                Expect(valjean.Checkout(ctx, library, "Les Miserables")).To(Succeed())
+                Expect(valjean.Books(ctx)).To(ContainElement(book))
+                Expect(valjean.Holds(ctx)).To(BeEmpty())
+            }, SpecTimeout(time.Second * 10))
         })  
     })
 
     When("the library does not have the book in question", func() {
-        It("tells the reader the book is unavailable", func() {
-            err := valjean.Checkout(library, "Les Miserables")
+        It("tells the reader the book is unavailable", func(ctx SpecContext) {
+            err := valjean.Checkout(ctx, library, "Les Miserables")
             Expect(error).To(MatchError("Les Miserables is not in the library catalog"))
-        })
+        }, SpecTimeout(time.Second * 5))
     })
 })
 ```
@@ -92,7 +88,7 @@ If you have a question, comment, bug report, feature request, etc. please open a
 
 Whether writing basic unit specs, complex integration specs, or even performance specs - Ginkgo gives you an expressive Domain-Specific Language (DSL) that will be familiar to users coming from frameworks such as [Quick](https://github.com/Quick/Quick), [RSpec](https://rspec.info), [Jasmine](https://jasmine.github.io), and [Busted](https://lunarmodules.github.io/busted/).  This style of testing is sometimes referred to as "Behavior-Driven Development" (BDD) though Ginkgo's utility extends beyond acceptance-level testing.
 
-With Ginkgo's DSL you can use nestable [`Describe`, `Context` and `When` container nodes](https://onsi.github.io/ginkgo/#organizing-specs-with-container-nodes) to help you organize your specs.  [`BeforeEach` and `AfterEach` setup nodes](https://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach) for setup and cleanup.  [`It` and `Specify` subject nodes](https://onsi.github.io/ginkgo/#spec-subjects-it) that hold your assertions. [`BeforeSuite` and `AfterSuite` nodes](https://onsi.github.io/ginkgo/#suite-setup-and-cleanup-beforesuite-and-aftersuite) to prep for and cleanup after a suite... and [much more!](https://onsi.github.io/ginkgo/#writing-specs)
+With Ginkgo's DSL you can use nestable [`Describe`, `Context` and `When` container nodes](https://onsi.github.io/ginkgo/#organizing-specs-with-container-nodes) to help you organize your specs.  [`BeforeEach` and `AfterEach` setup nodes](https://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach) for setup and cleanup.  [`It` and `Specify` subject nodes](https://onsi.github.io/ginkgo/#spec-subjects-it) that hold your assertions. [`BeforeSuite` and `AfterSuite` nodes](https://onsi.github.io/ginkgo/#suite-setup-and-cleanup-beforesuite-and-aftersuite) to prep for and cleanup after a suite... and [much more!](https://onsi.github.io/ginkgo/#writing-specs).
 
 At runtime, Ginkgo can run your specs in reproducibly [random order](https://onsi.github.io/ginkgo/#spec-randomization) and has sophisticated support for [spec parallelization](https://onsi.github.io/ginkgo/#spec-parallelization).  In fact, running specs in parallel is as easy as
 
@@ -100,7 +96,7 @@ At runtime, Ginkgo can run your specs in reproducibly [random order](https://ons
 ginkgo -p
 ```
 
-By following [established patterns for writing parallel specs](https://onsi.github.io/ginkgo/#patterns-for-parallel-integration-specs) you can build even large, complex integration suites that parallelize cleanly and run performantly.
+By following [established patterns for writing parallel specs](https://onsi.github.io/ginkgo/#patterns-for-parallel-integration-specs) you can build even large, complex integration suites that parallelize cleanly and run performantly.  And you don't have to worry about your spec suite hanging or leaving a mess behind - Ginkgo provides a per-node `context.Context` and the capability to interrupt the spec after a set period of time - and then clean up.
 
 As your suites grow Ginkgo helps you keep your specs organized with [labels](https://onsi.github.io/ginkgo/#spec-labels) and lets you easily run [subsets of specs](https://onsi.github.io/ginkgo/#filtering-specs), either [programmatically](https://onsi.github.io/ginkgo/#focused-specs) or on the [command line](https://onsi.github.io/ginkgo/#combining-filters).  And Ginkgo's reporting infrastructure generates machine-readable output in a [variety of formats](https://onsi.github.io/ginkgo/#generating-machine-readable-reports) _and_ allows you to build your own [custom reporting infrastructure](https://onsi.github.io/ginkgo/#generating-reports-programmatically).
 

--- a/vendor/github.com/onsi/ginkgo/v2/core_dsl.go
+++ b/vendor/github.com/onsi/ginkgo/v2/core_dsl.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/onsi/ginkgo/v2/formatter"
@@ -276,7 +275,7 @@ func RunSpecs(t GinkgoTestingT, description string, args ...interface{}) bool {
 	}
 
 	writer := GinkgoWriter.(*internal.Writer)
-	if reporterConfig.Verbose && suiteConfig.ParallelTotal == 1 {
+	if reporterConfig.Verbosity().GTE(types.VerbosityLevelVerbose) && suiteConfig.ParallelTotal == 1 {
 		writer.SetMode(internal.WriterModeStreamAndBuffer)
 	} else {
 		writer.SetMode(internal.WriterModeBufferOnly)
@@ -513,31 +512,7 @@ Note that By does not generate a new Ginkgo node - rather it is simply synctacti
 You can learn more about By here: https://onsi.github.io/ginkgo/#documenting-complex-specs-by
 */
 func By(text string, callback ...func()) {
-	if !global.Suite.InRunPhase() {
-		exitIfErr(types.GinkgoErrors.ByNotDuringRunPhase(types.NewCodeLocation(1)))
-	}
-	value := struct {
-		Text     string
-		Duration time.Duration
-	}{
-		Text: text,
-	}
-	t := time.Now()
-	global.Suite.SetProgressStepCursor(internal.ProgressStepCursor{
-		Text:         text,
-		CodeLocation: types.NewCodeLocation(1),
-		StartTime:    t,
-	})
-	AddReportEntry("By Step", ReportEntryVisibilityNever, Offset(1), &value, t)
-	formatter := formatter.NewWithNoColorBool(reporterConfig.NoColor)
-	GinkgoWriter.Println(formatter.F("{{bold}}STEP:{{/}} %s {{gray}}%s{{/}}", text, t.Format(types.GINKGO_TIME_FORMAT)))
-	if len(callback) == 1 {
-		callback[0]()
-		value.Duration = time.Since(t)
-	}
-	if len(callback) > 1 {
-		panic("just one callback per By, please")
-	}
+	exitIfErr(global.Suite.By(text, callback...))
 }
 
 /*

--- a/vendor/github.com/onsi/ginkgo/v2/internal/group.go
+++ b/vendor/github.com/onsi/ginkgo/v2/internal/group.go
@@ -116,6 +116,7 @@ func (g *group) initialReportForSpec(spec Spec) types.SpecReport {
 		LeafNodeText:                spec.FirstNodeWithType(types.NodeTypeIt).Text,
 		LeafNodeLabels:              []string(spec.FirstNodeWithType(types.NodeTypeIt).Labels),
 		ParallelProcess:             g.suite.config.ParallelProcess,
+		RunningInParallel:           g.suite.isRunningInParallel(),
 		IsSerial:                    spec.Nodes.HasNodeMarkedSerial(),
 		IsInOrderedContainer:        !spec.Nodes.FirstNodeMarkedOrdered().IsZero(),
 		MaxFlakeAttempts:            spec.Nodes.GetMaxFlakeAttempts(),
@@ -319,10 +320,10 @@ func (g *group) run(specs Specs) {
 				g.suite.outputInterceptor.StartInterceptingOutput()
 				if attempt > 0 {
 					if g.suite.currentSpecReport.MaxMustPassRepeatedly > 0 {
-						fmt.Fprintf(g.suite.writer, "\nGinkgo: Attempt #%d Passed.  Repeating...\n", attempt)
+						g.suite.handleSpecEvent(types.SpecEvent{SpecEventType: types.SpecEventSpecRepeat, Attempt: attempt})
 					}
 					if g.suite.currentSpecReport.MaxFlakeAttempts > 0 {
-						fmt.Fprintf(g.suite.writer, "\nGinkgo: Attempt #%d Failed.  Retrying...\n", attempt)
+						g.suite.handleSpecEvent(types.SpecEvent{SpecEventType: types.SpecEventSpecRetry, Attempt: attempt})
 					}
 				}
 
@@ -341,6 +342,10 @@ func (g *group) run(specs Specs) {
 				if g.suite.currentSpecReport.MaxFlakeAttempts > 0 {
 					if g.suite.currentSpecReport.State.Is(types.SpecStatePassed | types.SpecStateSkipped | types.SpecStateAborted | types.SpecStateInterrupted) {
 						break
+					} else if attempt < maxAttempts-1 {
+						af := types.AdditionalFailure{State: g.suite.currentSpecReport.State, Failure: g.suite.currentSpecReport.Failure}
+						af.Failure.Message = fmt.Sprintf("Failure recorded during attempt %d:\n%s", attempt+1, af.Failure.Message)
+						g.suite.currentSpecReport.AdditionalFailures = append(g.suite.currentSpecReport.AdditionalFailures, af)
 					}
 				}
 			}

--- a/vendor/github.com/onsi/ginkgo/v2/internal/node.go
+++ b/vendor/github.com/onsi/ginkgo/v2/internal/node.go
@@ -47,20 +47,19 @@ type Node struct {
 	ReportEachBody       func(types.SpecReport)
 	ReportAfterSuiteBody func(types.Report)
 
-	MarkedFocus                     bool
-	MarkedPending                   bool
-	MarkedSerial                    bool
-	MarkedOrdered                   bool
-	MarkedOncePerOrdered            bool
-	MarkedSuppressProgressReporting bool
-	FlakeAttempts                   int
-	MustPassRepeatedly              int
-	Labels                          Labels
-	PollProgressAfter               time.Duration
-	PollProgressInterval            time.Duration
-	NodeTimeout                     time.Duration
-	SpecTimeout                     time.Duration
-	GracePeriod                     time.Duration
+	MarkedFocus          bool
+	MarkedPending        bool
+	MarkedSerial         bool
+	MarkedOrdered        bool
+	MarkedOncePerOrdered bool
+	FlakeAttempts        int
+	MustPassRepeatedly   int
+	Labels               Labels
+	PollProgressAfter    time.Duration
+	PollProgressInterval time.Duration
+	NodeTimeout          time.Duration
+	SpecTimeout          time.Duration
+	GracePeriod          time.Duration
 
 	NodeIDWhereCleanupWasGenerated uint
 }
@@ -248,10 +247,7 @@ func NewNode(deprecationTracker *types.DeprecationTracker, nodeType types.NodeTy
 				appendError(types.GinkgoErrors.InvalidDecoratorForNodeType(node.CodeLocation, nodeType, "OncePerOrdered"))
 			}
 		case t == reflect.TypeOf(SuppressProgressReporting):
-			node.MarkedSuppressProgressReporting = bool(arg.(suppressProgressReporting))
-			if nodeType.Is(types.NodeTypeContainer) {
-				appendError(types.GinkgoErrors.InvalidDecoratorForNodeType(node.CodeLocation, nodeType, "SuppressProgressReporting"))
-			}
+			deprecationTracker.TrackDeprecation(types.Deprecations.SuppressProgressReporting())
 		case t == reflect.TypeOf(FlakeAttempts(0)):
 			node.FlakeAttempts = int(arg.(FlakeAttempts))
 			if !nodeType.Is(types.NodeTypesForContainerAndIt) {

--- a/vendor/github.com/onsi/ginkgo/v2/internal/progress_report.go
+++ b/vendor/github.com/onsi/ginkgo/v2/internal/progress_report.go
@@ -48,13 +48,10 @@ type ProgressStepCursor struct {
 	StartTime    time.Time
 }
 
-func NewProgressReport(isRunningInParallel bool, report types.SpecReport, currentNode Node, currentNodeStartTime time.Time, currentStep ProgressStepCursor, gwOutput string, additionalReports []string, sourceRoots []string, includeAll bool) (types.ProgressReport, error) {
+func NewProgressReport(isRunningInParallel bool, report types.SpecReport, currentNode Node, currentNodeStartTime time.Time, currentStep types.SpecEvent, gwOutput string, timelineLocation types.TimelineLocation, additionalReports []string, sourceRoots []string, includeAll bool) (types.ProgressReport, error) {
 	pr := types.ProgressReport{
-		ParallelProcess:   report.ParallelProcess,
-		RunningInParallel: isRunningInParallel,
-
-		Time: time.Now(),
-
+		ParallelProcess:         report.ParallelProcess,
+		RunningInParallel:       isRunningInParallel,
 		ContainerHierarchyTexts: report.ContainerHierarchyTexts,
 		LeafNodeText:            report.LeafNodeText,
 		LeafNodeLocation:        report.LeafNodeLocation,
@@ -65,14 +62,14 @@ func NewProgressReport(isRunningInParallel bool, report types.SpecReport, curren
 		CurrentNodeLocation:  currentNode.CodeLocation,
 		CurrentNodeStartTime: currentNodeStartTime,
 
-		CurrentStepText:      currentStep.Text,
+		CurrentStepText:      currentStep.Message,
 		CurrentStepLocation:  currentStep.CodeLocation,
-		CurrentStepStartTime: currentStep.StartTime,
+		CurrentStepStartTime: currentStep.TimelineLocation.Time,
 
 		AdditionalReports: additionalReports,
 
 		CapturedGinkgoWriterOutput: gwOutput,
-		GinkgoWriterOffset:         len(gwOutput),
+		TimelineLocation:           timelineLocation,
 	}
 
 	goroutines, err := extractRunningGoroutines()

--- a/vendor/github.com/onsi/ginkgo/v2/internal/report_entry.go
+++ b/vendor/github.com/onsi/ginkgo/v2/internal/report_entry.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"reflect"
 	"time"
 
 	"github.com/onsi/ginkgo/v2/types"
@@ -13,20 +12,20 @@ func NewReportEntry(name string, cl types.CodeLocation, args ...interface{}) (Re
 	out := ReportEntry{
 		Visibility: types.ReportEntryVisibilityAlways,
 		Name:       name,
-		Time:       time.Now(),
 		Location:   cl,
+		Time:       time.Now(),
 	}
 	var didSetValue = false
 	for _, arg := range args {
-		switch reflect.TypeOf(arg) {
-		case reflect.TypeOf(types.ReportEntryVisibilityAlways):
-			out.Visibility = arg.(types.ReportEntryVisibility)
-		case reflect.TypeOf(types.CodeLocation{}):
-			out.Location = arg.(types.CodeLocation)
-		case reflect.TypeOf(Offset(0)):
-			out.Location = types.NewCodeLocation(2 + int(arg.(Offset)))
-		case reflect.TypeOf(out.Time):
-			out.Time = arg.(time.Time)
+		switch x := arg.(type) {
+		case types.ReportEntryVisibility:
+			out.Visibility = x
+		case types.CodeLocation:
+			out.Location = x
+		case Offset:
+			out.Location = types.NewCodeLocation(2 + int(x))
+		case time.Time:
+			out.Time = x
 		default:
 			if didSetValue {
 				return ReportEntry{}, types.GinkgoErrors.TooManyReportEntryValues(out.Location, arg)

--- a/vendor/github.com/onsi/ginkgo/v2/internal/suite.go
+++ b/vendor/github.com/onsi/ginkgo/v2/internal/suite.go
@@ -44,7 +44,8 @@ type Suite struct {
 
 	currentSpecContext *specContext
 
-	progressStepCursor ProgressStepCursor
+	currentByStep types.SpecEvent
+	timelineOrder int
 
 	/*
 		We don't need to lock around all operations.  Just those that *could* happen concurrently.
@@ -236,19 +237,69 @@ func (suite *Suite) pushCleanupNode(node Node) error {
 	return nil
 }
 
-/*
-  Pushing and popping the Step Cursor stack
-*/
-
-func (suite *Suite) SetProgressStepCursor(cursor ProgressStepCursor) {
+func (suite *Suite) generateTimelineLocation() types.TimelineLocation {
 	suite.selectiveLock.Lock()
 	defer suite.selectiveLock.Unlock()
 
-	suite.progressStepCursor = cursor
+	suite.timelineOrder += 1
+	return types.TimelineLocation{
+		Offset: len(suite.currentSpecReport.CapturedGinkgoWriterOutput) + suite.writer.Len(),
+		Order:  suite.timelineOrder,
+		Time:   time.Now(),
+	}
+}
+
+func (suite *Suite) handleSpecEvent(event types.SpecEvent) types.SpecEvent {
+	event.TimelineLocation = suite.generateTimelineLocation()
+	suite.selectiveLock.Lock()
+	suite.currentSpecReport.SpecEvents = append(suite.currentSpecReport.SpecEvents, event)
+	suite.selectiveLock.Unlock()
+	suite.reporter.EmitSpecEvent(event)
+	return event
+}
+
+func (suite *Suite) handleSpecEventEnd(eventType types.SpecEventType, startEvent types.SpecEvent) {
+	event := startEvent
+	event.SpecEventType = eventType
+	event.TimelineLocation = suite.generateTimelineLocation()
+	event.Duration = event.TimelineLocation.Time.Sub(startEvent.TimelineLocation.Time)
+	suite.selectiveLock.Lock()
+	suite.currentSpecReport.SpecEvents = append(suite.currentSpecReport.SpecEvents, event)
+	suite.selectiveLock.Unlock()
+	suite.reporter.EmitSpecEvent(event)
+}
+
+func (suite *Suite) By(text string, callback ...func()) error {
+	cl := types.NewCodeLocation(2)
+	if suite.phase != PhaseRun {
+		return types.GinkgoErrors.ByNotDuringRunPhase(cl)
+	}
+
+	event := suite.handleSpecEvent(types.SpecEvent{
+		SpecEventType: types.SpecEventByStart,
+		CodeLocation:  cl,
+		Message:       text,
+	})
+	suite.selectiveLock.Lock()
+	suite.currentByStep = event
+	suite.selectiveLock.Unlock()
+
+	if len(callback) == 1 {
+		defer func() {
+			suite.selectiveLock.Lock()
+			suite.currentByStep = types.SpecEvent{}
+			suite.selectiveLock.Unlock()
+			suite.handleSpecEventEnd(types.SpecEventByEnd, event)
+		}()
+		callback[0]()
+	} else if len(callback) > 1 {
+		panic("just one callback per By, please")
+	}
+	return nil
 }
 
 /*
-  Spec Running methods - used during PhaseRun
+Spec Running methods - used during PhaseRun
 */
 func (suite *Suite) CurrentSpecReport() types.SpecReport {
 	suite.selectiveLock.Lock()
@@ -263,16 +314,20 @@ func (suite *Suite) CurrentSpecReport() types.SpecReport {
 }
 
 func (suite *Suite) AddReportEntry(entry ReportEntry) error {
-	suite.selectiveLock.Lock()
-	defer suite.selectiveLock.Unlock()
 	if suite.phase != PhaseRun {
 		return types.GinkgoErrors.AddReportEntryNotDuringRunPhase(entry.Location)
 	}
+	entry.TimelineLocation = suite.generateTimelineLocation()
+	entry.Time = entry.TimelineLocation.Time
+	suite.selectiveLock.Lock()
 	suite.currentSpecReport.ReportEntries = append(suite.currentSpecReport.ReportEntries, entry)
+	suite.selectiveLock.Unlock()
+	suite.reporter.EmitReportEntry(entry)
 	return nil
 }
 
 func (suite *Suite) generateProgressReport(fullReport bool) types.ProgressReport {
+	timelineLocation := suite.generateTimelineLocation()
 	suite.selectiveLock.Lock()
 	defer suite.selectiveLock.Unlock()
 
@@ -280,10 +335,8 @@ func (suite *Suite) generateProgressReport(fullReport bool) types.ProgressReport
 	if suite.currentSpecContext != nil {
 		additionalReports = suite.currentSpecContext.QueryProgressReporters()
 	}
-	stepCursor := suite.progressStepCursor
-
 	gwOutput := suite.currentSpecReport.CapturedGinkgoWriterOutput + string(suite.writer.Bytes())
-	pr, err := NewProgressReport(suite.isRunningInParallel(), suite.currentSpecReport, suite.currentNode, suite.currentNodeStartTime, stepCursor, gwOutput, additionalReports, suite.config.SourceRoots, fullReport)
+	pr, err := NewProgressReport(suite.isRunningInParallel(), suite.currentSpecReport, suite.currentNode, suite.currentNodeStartTime, suite.currentByStep, gwOutput, timelineLocation, additionalReports, suite.config.SourceRoots, fullReport)
 
 	if err != nil {
 		fmt.Printf("{{red}}Failed to generate progress report:{{/}}\n%s\n", err.Error())
@@ -424,9 +477,10 @@ func (suite *Suite) runBeforeSuite(numSpecsThatWillBeRun int) {
 	if !beforeSuiteNode.IsZero() && numSpecsThatWillBeRun > 0 {
 		suite.selectiveLock.Lock()
 		suite.currentSpecReport = types.SpecReport{
-			LeafNodeType:     beforeSuiteNode.NodeType,
-			LeafNodeLocation: beforeSuiteNode.CodeLocation,
-			ParallelProcess:  suite.config.ParallelProcess,
+			LeafNodeType:      beforeSuiteNode.NodeType,
+			LeafNodeLocation:  beforeSuiteNode.CodeLocation,
+			ParallelProcess:   suite.config.ParallelProcess,
+			RunningInParallel: suite.isRunningInParallel(),
 		}
 		suite.selectiveLock.Unlock()
 
@@ -445,9 +499,10 @@ func (suite *Suite) runAfterSuiteCleanup(numSpecsThatWillBeRun int) {
 	if !afterSuiteNode.IsZero() && numSpecsThatWillBeRun > 0 {
 		suite.selectiveLock.Lock()
 		suite.currentSpecReport = types.SpecReport{
-			LeafNodeType:     afterSuiteNode.NodeType,
-			LeafNodeLocation: afterSuiteNode.CodeLocation,
-			ParallelProcess:  suite.config.ParallelProcess,
+			LeafNodeType:      afterSuiteNode.NodeType,
+			LeafNodeLocation:  afterSuiteNode.CodeLocation,
+			ParallelProcess:   suite.config.ParallelProcess,
+			RunningInParallel: suite.isRunningInParallel(),
 		}
 		suite.selectiveLock.Unlock()
 
@@ -461,9 +516,10 @@ func (suite *Suite) runAfterSuiteCleanup(numSpecsThatWillBeRun int) {
 		for _, cleanupNode := range afterSuiteCleanup {
 			suite.selectiveLock.Lock()
 			suite.currentSpecReport = types.SpecReport{
-				LeafNodeType:     cleanupNode.NodeType,
-				LeafNodeLocation: cleanupNode.CodeLocation,
-				ParallelProcess:  suite.config.ParallelProcess,
+				LeafNodeType:      cleanupNode.NodeType,
+				LeafNodeLocation:  cleanupNode.CodeLocation,
+				ParallelProcess:   suite.config.ParallelProcess,
+				RunningInParallel: suite.isRunningInParallel(),
 			}
 			suite.selectiveLock.Unlock()
 
@@ -478,10 +534,11 @@ func (suite *Suite) runReportAfterSuite() {
 	for _, node := range suite.suiteNodes.WithType(types.NodeTypeReportAfterSuite) {
 		suite.selectiveLock.Lock()
 		suite.currentSpecReport = types.SpecReport{
-			LeafNodeType:     node.NodeType,
-			LeafNodeLocation: node.CodeLocation,
-			LeafNodeText:     node.Text,
-			ParallelProcess:  suite.config.ParallelProcess,
+			LeafNodeType:      node.NodeType,
+			LeafNodeLocation:  node.CodeLocation,
+			LeafNodeText:      node.Text,
+			ParallelProcess:   suite.config.ParallelProcess,
+			RunningInParallel: suite.isRunningInParallel(),
 		}
 		suite.selectiveLock.Unlock()
 
@@ -608,6 +665,7 @@ func (suite *Suite) runSuiteNode(node Node) {
 
 	if err != nil && !suite.currentSpecReport.State.Is(types.SpecStateFailureStates) {
 		suite.currentSpecReport.State, suite.currentSpecReport.Failure = types.SpecStateFailed, suite.failureForLeafNodeWithMessage(node, err.Error())
+		suite.reporter.EmitFailure(suite.currentSpecReport.State, suite.currentSpecReport.Failure)
 	}
 
 	suite.currentSpecReport.EndTime = time.Now()
@@ -627,6 +685,7 @@ func (suite *Suite) runReportAfterSuiteNode(node Node, report types.Report) {
 		aggregatedReport, err := suite.client.BlockUntilAggregatedNonprimaryProcsReport()
 		if err != nil {
 			suite.currentSpecReport.State, suite.currentSpecReport.Failure = types.SpecStateFailed, suite.failureForLeafNodeWithMessage(node, err.Error())
+			suite.reporter.EmitFailure(suite.currentSpecReport.State, suite.currentSpecReport.Failure)
 			return
 		}
 		report = report.Add(aggregatedReport)
@@ -662,7 +721,7 @@ func (suite *Suite) runNode(node Node, specDeadline time.Time, text string) (typ
 	suite.selectiveLock.Lock()
 	suite.currentNode = node
 	suite.currentNodeStartTime = time.Now()
-	suite.progressStepCursor = ProgressStepCursor{}
+	suite.currentByStep = types.SpecEvent{}
 	suite.selectiveLock.Unlock()
 	defer func() {
 		suite.selectiveLock.Lock()
@@ -671,13 +730,18 @@ func (suite *Suite) runNode(node Node, specDeadline time.Time, text string) (typ
 		suite.selectiveLock.Unlock()
 	}()
 
-	if suite.config.EmitSpecProgress && !node.MarkedSuppressProgressReporting {
-		if text == "" {
-			text = "TOP-LEVEL"
-		}
-		s := fmt.Sprintf("[%s] %s\n  %s\n", node.NodeType.String(), text, node.CodeLocation.String())
-		suite.writer.Write([]byte(s))
+	if text == "" {
+		text = "TOP-LEVEL"
 	}
+	event := suite.handleSpecEvent(types.SpecEvent{
+		SpecEventType: types.SpecEventNodeStart,
+		NodeType:      node.NodeType,
+		Message:       text,
+		CodeLocation:  node.CodeLocation,
+	})
+	defer func() {
+		suite.handleSpecEventEnd(types.SpecEventNodeEnd, event)
+	}()
 
 	var failure types.Failure
 	failure.FailureNodeType, failure.FailureNodeLocation = node.NodeType, node.CodeLocation
@@ -697,18 +761,23 @@ func (suite *Suite) runNode(node Node, specDeadline time.Time, text string) (typ
 
 	now := time.Now()
 	deadline := suite.deadline
+	timeoutInPlay := "suite"
 	if deadline.IsZero() || (!specDeadline.IsZero() && specDeadline.Before(deadline)) {
 		deadline = specDeadline
+		timeoutInPlay = "spec"
 	}
 	if node.NodeTimeout > 0 && (deadline.IsZero() || deadline.Sub(now) > node.NodeTimeout) {
 		deadline = now.Add(node.NodeTimeout)
+		timeoutInPlay = "node"
 	}
 	if (!deadline.IsZero() && deadline.Before(now)) || interruptStatus.Interrupted() {
 		//we're out of time already.  let's wait for a NodeTimeout if we have it, or GracePeriod if we don't
 		if node.NodeTimeout > 0 {
 			deadline = now.Add(node.NodeTimeout)
+			timeoutInPlay = "node"
 		} else {
 			deadline = now.Add(gracePeriod)
+			timeoutInPlay = "grace period"
 		}
 	}
 
@@ -743,6 +812,7 @@ func (suite *Suite) runNode(node Node, specDeadline time.Time, text string) (typ
 			}
 
 			outcomeFromRun, failureFromRun := suite.failer.Drain()
+			failureFromRun.TimelineLocation = suite.generateTimelineLocation()
 			outcomeC <- outcomeFromRun
 			failureC <- failureFromRun
 		}()
@@ -772,23 +842,33 @@ func (suite *Suite) runNode(node Node, specDeadline time.Time, text string) (typ
 		select {
 		case outcomeFromRun := <-outcomeC:
 			failureFromRun := <-failureC
-			if outcome == types.SpecStateInterrupted {
-				// we've already been interrupted.  we just managed to actually exit
+			if outcome.Is(types.SpecStateInterrupted | types.SpecStateTimedout) {
+				// we've already been interrupted/timed out.  we just managed to actually exit
 				// before the grace period elapsed
-				return outcome, failure
-			} else if outcome == types.SpecStateTimedout {
-				// we've already timed out.  we just managed to actually exit
-				// before the grace period elapsed.  if we have a failure message we should include it
+				// if we have a failure message we attach it as an additional failure
 				if outcomeFromRun != types.SpecStatePassed {
-					failure.Location, failure.ForwardedPanic = failureFromRun.Location, failureFromRun.ForwardedPanic
-					failure.Message = "This spec timed out and reported the following failure after the timeout:\n\n" + failureFromRun.Message
+					additionalFailure := types.AdditionalFailure{
+						State:   outcomeFromRun,
+						Failure: failure, //we make a copy - this will include all the configuration set up above...
+					}
+					//...and then we update the failure with the details from failureFromRun
+					additionalFailure.Failure.Location, additionalFailure.Failure.ForwardedPanic, additionalFailure.Failure.TimelineLocation = failureFromRun.Location, failureFromRun.ForwardedPanic, failureFromRun.TimelineLocation
+					additionalFailure.Failure.ProgressReport = types.ProgressReport{}
+					if outcome == types.SpecStateTimedout {
+						additionalFailure.Failure.Message = fmt.Sprintf("A %s timeout occurred and then the following failure was recorded in the timedout node before it exited:\n%s", timeoutInPlay, failureFromRun.Message)
+					} else {
+						additionalFailure.Failure.Message = fmt.Sprintf("An interrupt occurred and then the following failure was recorded in the interrupted node before it exited:\n%s", failureFromRun.Message)
+					}
+					suite.reporter.EmitFailure(additionalFailure.State, additionalFailure.Failure)
+					failure.AdditionalFailure = &additionalFailure
 				}
 				return outcome, failure
 			}
 			if outcomeFromRun.Is(types.SpecStatePassed) {
 				return outcomeFromRun, types.Failure{}
 			} else {
-				failure.Message, failure.Location, failure.ForwardedPanic = failureFromRun.Message, failureFromRun.Location, failureFromRun.ForwardedPanic
+				failure.Message, failure.Location, failure.ForwardedPanic, failure.TimelineLocation = failureFromRun.Message, failureFromRun.Location, failureFromRun.ForwardedPanic, failureFromRun.TimelineLocation
+				suite.reporter.EmitFailure(outcomeFromRun, failure)
 				return outcomeFromRun, failure
 			}
 		case <-gracePeriodChannel:
@@ -801,10 +881,12 @@ func (suite *Suite) runNode(node Node, specDeadline time.Time, text string) (typ
 		case <-deadlineChannel:
 			// we're out of time - the outcome is a timeout and we capture the failure and progress report
 			outcome = types.SpecStateTimedout
-			failure.Message, failure.Location = "Timedout", node.CodeLocation
+			failure.Message, failure.Location, failure.TimelineLocation = fmt.Sprintf("A %s timeout occurred", timeoutInPlay), node.CodeLocation, suite.generateTimelineLocation()
 			failure.ProgressReport = suite.generateProgressReport(false).WithoutCapturedGinkgoWriterOutput()
-			failure.ProgressReport.Message = "{{bold}}This is the Progress Report generated when the timeout occurred:{{/}}"
+			failure.ProgressReport.Message = fmt.Sprintf("{{bold}}This is the Progress Report generated when the %s timeout occurred:{{/}}", timeoutInPlay)
 			deadlineChannel = nil
+			suite.reporter.EmitFailure(outcome, failure)
+
 			// tell the spec to stop.  it's important we generate the progress report first to make sure we capture where
 			// the spec is actually stuck
 			sc.cancel()
@@ -814,36 +896,36 @@ func (suite *Suite) runNode(node Node, specDeadline time.Time, text string) (typ
 			interruptStatus = suite.interruptHandler.Status()
 			deadlineChannel = nil // don't worry about deadlines, time's up now
 
+			failureTimelineLocation := suite.generateTimelineLocation()
+			progressReport := suite.generateProgressReport(true)
+
 			if outcome == types.SpecStateInvalid {
 				outcome = types.SpecStateInterrupted
-				failure.Message, failure.Location = interruptStatus.Message(), node.CodeLocation
+				failure.Message, failure.Location, failure.TimelineLocation = interruptStatus.Message(), node.CodeLocation, failureTimelineLocation
 				if interruptStatus.ShouldIncludeProgressReport() {
-					failure.ProgressReport = suite.generateProgressReport(true).WithoutCapturedGinkgoWriterOutput()
+					failure.ProgressReport = progressReport.WithoutCapturedGinkgoWriterOutput()
 					failure.ProgressReport.Message = "{{bold}}This is the Progress Report generated when the interrupt was received:{{/}}"
 				}
+				suite.reporter.EmitFailure(outcome, failure)
 			}
 
-			var report types.ProgressReport
-			if interruptStatus.ShouldIncludeProgressReport() {
-				report = suite.generateProgressReport(false)
-			}
-
+			progressReport = progressReport.WithoutOtherGoroutines()
 			sc.cancel()
 
 			if interruptStatus.Level == interrupt_handler.InterruptLevelBailOut {
 				if interruptStatus.ShouldIncludeProgressReport() {
-					report.Message = fmt.Sprintf("{{bold}}{{orange}}%s{{/}}\n{{bold}}{{red}}Final interrupt received{{/}}; Ginkgo will not run any cleanup or reporting nodes and will terminate as soon as possible.\nHere's a current progress report:", interruptStatus.Message())
-					suite.emitProgressReport(report)
+					progressReport.Message = fmt.Sprintf("{{bold}}{{orange}}%s{{/}}\n{{bold}}{{red}}Final interrupt received{{/}}; Ginkgo will not run any cleanup or reporting nodes and will terminate as soon as possible.\nHere's a current progress report:", interruptStatus.Message())
+					suite.emitProgressReport(progressReport)
 				}
 				return outcome, failure
 			}
 			if interruptStatus.ShouldIncludeProgressReport() {
 				if interruptStatus.Level == interrupt_handler.InterruptLevelCleanupAndReport {
-					report.Message = fmt.Sprintf("{{bold}}{{orange}}%s{{/}}\nFirst interrupt received; Ginkgo will run any cleanup and reporting nodes but will skip all remaining specs.  {{bold}}Interrupt again to skip cleanup{{/}}.\nHere's a current progress report:", interruptStatus.Message())
+					progressReport.Message = fmt.Sprintf("{{bold}}{{orange}}%s{{/}}\nFirst interrupt received; Ginkgo will run any cleanup and reporting nodes but will skip all remaining specs.  {{bold}}Interrupt again to skip cleanup{{/}}.\nHere's a current progress report:", interruptStatus.Message())
 				} else if interruptStatus.Level == interrupt_handler.InterruptLevelReportOnly {
-					report.Message = fmt.Sprintf("{{bold}}{{orange}}%s{{/}}\nSecond interrupt received; Ginkgo will run any reporting nodes but will skip all remaining specs and cleanup nodes.  {{bold}}Interrupt again to bail immediately{{/}}.\nHere's a current progress report:", interruptStatus.Message())
+					progressReport.Message = fmt.Sprintf("{{bold}}{{orange}}%s{{/}}\nSecond interrupt received; Ginkgo will run any reporting nodes but will skip all remaining specs and cleanup nodes.  {{bold}}Interrupt again to bail immediately{{/}}.\nHere's a current progress report:", interruptStatus.Message())
 				}
-				suite.emitProgressReport(report)
+				suite.emitProgressReport(progressReport)
 			}
 
 			if gracePeriodChannel == nil {
@@ -864,10 +946,12 @@ func (suite *Suite) runNode(node Node, specDeadline time.Time, text string) (typ
 	}
 }
 
+// TODO: search for usages and consider if reporter.EmitFailure() is necessary
 func (suite *Suite) failureForLeafNodeWithMessage(node Node, message string) types.Failure {
 	return types.Failure{
 		Message:             message,
 		Location:            node.CodeLocation,
+		TimelineLocation:    suite.generateTimelineLocation(),
 		FailureNodeContext:  types.FailureNodeIsLeafNode,
 		FailureNodeType:     node.NodeType,
 		FailureNodeLocation: node.CodeLocation,

--- a/vendor/github.com/onsi/ginkgo/v2/internal/writer.go
+++ b/vendor/github.com/onsi/ginkgo/v2/internal/writer.go
@@ -22,24 +22,30 @@ type WriterInterface interface {
 
 	Truncate()
 	Bytes() []byte
+	Len() int
 }
 
-//Writer implements WriterInterface and GinkgoWriterInterface
+// Writer implements WriterInterface and GinkgoWriterInterface
 type Writer struct {
 	buffer    *bytes.Buffer
 	outWriter io.Writer
 	lock      *sync.Mutex
 	mode      WriterMode
 
+	streamIndent []byte
+	indentNext   bool
+
 	teeWriters []io.Writer
 }
 
 func NewWriter(outWriter io.Writer) *Writer {
 	return &Writer{
-		buffer:    &bytes.Buffer{},
-		lock:      &sync.Mutex{},
-		outWriter: outWriter,
-		mode:      WriterModeStreamAndBuffer,
+		buffer:       &bytes.Buffer{},
+		lock:         &sync.Mutex{},
+		outWriter:    outWriter,
+		mode:         WriterModeStreamAndBuffer,
+		streamIndent: []byte("  "),
+		indentNext:   true,
 	}
 }
 
@@ -48,6 +54,14 @@ func (w *Writer) SetMode(mode WriterMode) {
 	defer w.lock.Unlock()
 	w.mode = mode
 }
+
+func (w *Writer) Len() int {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	return w.buffer.Len()
+}
+
+var newline = []byte("\n")
 
 func (w *Writer) Write(b []byte) (n int, err error) {
 	w.lock.Lock()
@@ -58,7 +72,21 @@ func (w *Writer) Write(b []byte) (n int, err error) {
 	}
 
 	if w.mode == WriterModeStreamAndBuffer {
-		w.outWriter.Write(b)
+		line, remaining, found := []byte{}, b, false
+		for len(remaining) > 0 {
+			line, remaining, found = bytes.Cut(remaining, newline)
+			if len(line) > 0 {
+				if w.indentNext {
+					w.outWriter.Write(w.streamIndent)
+					w.indentNext = false
+				}
+				w.outWriter.Write(line)
+			}
+			if found {
+				w.outWriter.Write(newline)
+				w.indentNext = true
+			}
+		}
 	}
 	return w.buffer.Write(b)
 }
@@ -78,7 +106,7 @@ func (w *Writer) Bytes() []byte {
 	return copied
 }
 
-//GinkgoWriterInterface
+// GinkgoWriterInterface
 func (w *Writer) TeeTo(writer io.Writer) {
 	w.lock.Lock()
 	defer w.lock.Unlock()

--- a/vendor/github.com/onsi/ginkgo/v2/reporters/default_reporter.go
+++ b/vendor/github.com/onsi/ginkgo/v2/reporters/default_reporter.go
@@ -30,6 +30,8 @@ type DefaultReporter struct {
 	specDenoter  string
 	retryDenoter string
 	formatter    formatter.Formatter
+
+	runningInParallel bool
 }
 
 func NewDefaultReporterUnderTest(conf types.ReporterConfig, writer io.Writer) *DefaultReporter {
@@ -97,230 +99,10 @@ func (r *DefaultReporter) SuiteWillBegin(report types.Report) {
 	}
 }
 
-func (r *DefaultReporter) WillRun(report types.SpecReport) {
-	if r.conf.Verbosity().LT(types.VerbosityLevelVerbose) || report.State.Is(types.SpecStatePending|types.SpecStateSkipped) {
-		return
-	}
-
-	r.emitDelimiter()
-	indentation := uint(0)
-	if report.LeafNodeType.Is(types.NodeTypesForSuiteLevelNodes) {
-		r.emitBlock(r.f("{{bold}}[%s] %s{{/}}", report.LeafNodeType.String(), report.LeafNodeText))
-	} else {
-		if len(report.ContainerHierarchyTexts) > 0 {
-			r.emitBlock(r.cycleJoin(report.ContainerHierarchyTexts, " "))
-			indentation = 1
-		}
-		line := r.fi(indentation, "{{bold}}%s{{/}}", report.LeafNodeText)
-		labels := report.Labels()
-		if len(labels) > 0 {
-			line += r.f(" {{coral}}[%s]{{/}}", strings.Join(labels, ", "))
-		}
-		r.emitBlock(line)
-	}
-	r.emitBlock(r.fi(indentation, "{{gray}}%s{{/}}", report.LeafNodeLocation))
-}
-
-func (r *DefaultReporter) DidRun(report types.SpecReport) {
-	v := r.conf.Verbosity()
-	var header, highlightColor string
-	includeRuntime, emitGinkgoWriterOutput, stream, denoter := true, true, false, r.specDenoter
-	succinctLocationBlock := v.Is(types.VerbosityLevelSuccinct)
-
-	hasGW := report.CapturedGinkgoWriterOutput != ""
-	hasStd := report.CapturedStdOutErr != ""
-	hasEmittableReports := report.ReportEntries.HasVisibility(types.ReportEntryVisibilityAlways) || (report.ReportEntries.HasVisibility(types.ReportEntryVisibilityFailureOrVerbose) && (!report.Failure.IsZero() || v.GTE(types.VerbosityLevelVerbose)))
-
-	if report.LeafNodeType.Is(types.NodeTypesForSuiteLevelNodes) {
-		denoter = fmt.Sprintf("[%s]", report.LeafNodeType)
-	}
-
-	highlightColor = r.highlightColorForState(report.State)
-
-	switch report.State {
-	case types.SpecStatePassed:
-		succinctLocationBlock = v.LT(types.VerbosityLevelVerbose)
-		emitGinkgoWriterOutput = (r.conf.AlwaysEmitGinkgoWriter || v.GTE(types.VerbosityLevelVerbose)) && hasGW
-		if report.LeafNodeType.Is(types.NodeTypesForSuiteLevelNodes) {
-			if v.GTE(types.VerbosityLevelVerbose) || hasStd || hasEmittableReports {
-				header = fmt.Sprintf("%s PASSED", denoter)
-			} else {
-				return
-			}
-		} else {
-			header, stream = denoter, true
-			if report.NumAttempts > 1 && report.MaxFlakeAttempts > 1 {
-				header, stream = fmt.Sprintf("%s [FLAKEY TEST - TOOK %d ATTEMPTS TO PASS]", r.retryDenoter, report.NumAttempts), false
-			}
-			if report.RunTime > r.conf.SlowSpecThreshold {
-				header, stream = fmt.Sprintf("%s [SLOW TEST]", header), false
-			}
-		}
-		if hasStd || emitGinkgoWriterOutput || hasEmittableReports {
-			stream = false
-		}
-	case types.SpecStatePending:
-		includeRuntime, emitGinkgoWriterOutput = false, false
-		if v.Is(types.VerbosityLevelSuccinct) {
-			header, stream = "P", true
-		} else {
-			header, succinctLocationBlock = "P [PENDING]", v.LT(types.VerbosityLevelVeryVerbose)
-		}
-	case types.SpecStateSkipped:
-		if report.Failure.Message != "" || v.Is(types.VerbosityLevelVeryVerbose) {
-			header = "S [SKIPPED]"
-		} else {
-			header, stream = "S", true
-		}
-	case types.SpecStateFailed:
-		header = fmt.Sprintf("%s [FAILED]", denoter)
-	case types.SpecStateTimedout:
-		header = fmt.Sprintf("%s [TIMEDOUT]", denoter)
-	case types.SpecStatePanicked:
-		header = fmt.Sprintf("%s! [PANICKED]", denoter)
-	case types.SpecStateInterrupted:
-		header = fmt.Sprintf("%s! [INTERRUPTED]", denoter)
-	case types.SpecStateAborted:
-		header = fmt.Sprintf("%s! [ABORTED]", denoter)
-	}
-
-	if report.State.Is(types.SpecStateFailureStates) && report.MaxMustPassRepeatedly > 1 {
-		header, stream = fmt.Sprintf("%s DURING REPETITION #%d", header, report.NumAttempts), false
-	}
-	// Emit stream and return
-	if stream {
-		r.emit(r.f(highlightColor + header + "{{/}}"))
-		return
-	}
-
-	// Emit header
-	r.emitDelimiter()
-	if includeRuntime {
-		header = r.f("%s [%.3f seconds]", header, report.RunTime.Seconds())
-	}
-	r.emitBlock(r.f(highlightColor + header + "{{/}}"))
-
-	// Emit Code Location Block
-	r.emitBlock(r.codeLocationBlock(report, highlightColor, succinctLocationBlock, false))
-
-	//Emit Stdout/Stderr Output
-	if hasStd {
-		r.emitBlock("\n")
-		r.emitBlock(r.fi(1, "{{gray}}Begin Captured StdOut/StdErr Output >>{{/}}"))
-		r.emitBlock(r.fi(2, "%s", report.CapturedStdOutErr))
-		r.emitBlock(r.fi(1, "{{gray}}<< End Captured StdOut/StdErr Output{{/}}"))
-	}
-
-	//Emit Captured GinkgoWriter Output
-	if emitGinkgoWriterOutput && hasGW {
-		r.emitBlock("\n")
-		r.emitGinkgoWriterOutput(1, report.CapturedGinkgoWriterOutput, 0)
-	}
-
-	if hasEmittableReports {
-		r.emitBlock("\n")
-		r.emitBlock(r.fi(1, "{{gray}}Begin Report Entries >>{{/}}"))
-		reportEntries := report.ReportEntries.WithVisibility(types.ReportEntryVisibilityAlways)
-		if !report.Failure.IsZero() || v.GTE(types.VerbosityLevelVerbose) {
-			reportEntries = report.ReportEntries.WithVisibility(types.ReportEntryVisibilityAlways, types.ReportEntryVisibilityFailureOrVerbose)
-		}
-		for _, entry := range reportEntries {
-			r.emitBlock(r.fi(2, "{{bold}}"+entry.Name+"{{gray}} - %s @ %s{{/}}", entry.Location, entry.Time.Format(types.GINKGO_TIME_FORMAT)))
-			if representation := entry.StringRepresentation(); representation != "" {
-				r.emitBlock(r.fi(3, representation))
-			}
-		}
-		r.emitBlock(r.fi(1, "{{gray}}<< End Report Entries{{/}}"))
-	}
-
-	// Emit Failure Message
-	if !report.Failure.IsZero() {
-		r.emitBlock("\n")
-		r.EmitFailure(1, report.State, report.Failure, false)
-	}
-
-	if len(report.AdditionalFailures) > 0 {
-		if v.GTE(types.VerbosityLevelVerbose) {
-			r.emitBlock("\n")
-			r.emitBlock(r.fi(1, "{{bold}}There were additional failures detected after the initial failure:{{/}}"))
-			for i, additionalFailure := range report.AdditionalFailures {
-				r.EmitFailure(2, additionalFailure.State, additionalFailure.Failure, true)
-				if i < len(report.AdditionalFailures)-1 {
-					r.emitBlock(r.fi(2, "{{gray}}%s{{/}}", strings.Repeat("-", 10)))
-				}
-			}
-		} else {
-			r.emitBlock("\n")
-			r.emitBlock(r.fi(1, "{{bold}}There were additional failures detected after the initial failure.  Here's a summary - for full details run Ginkgo in verbose mode:{{/}}"))
-			for _, additionalFailure := range report.AdditionalFailures {
-				r.emitBlock(r.fi(2, r.highlightColorForState(additionalFailure.State)+"[%s]{{/}} in [%s] at %s",
-					r.humanReadableState(additionalFailure.State),
-					additionalFailure.Failure.FailureNodeType,
-					additionalFailure.Failure.Location,
-				))
-			}
-
-		}
-	}
-
-	r.emitDelimiter()
-}
-
-func (r *DefaultReporter) highlightColorForState(state types.SpecState) string {
-	switch state {
-	case types.SpecStatePassed:
-		return "{{green}}"
-	case types.SpecStatePending:
-		return "{{yellow}}"
-	case types.SpecStateSkipped:
-		return "{{cyan}}"
-	case types.SpecStateFailed:
-		return "{{red}}"
-	case types.SpecStateTimedout:
-		return "{{orange}}"
-	case types.SpecStatePanicked:
-		return "{{magenta}}"
-	case types.SpecStateInterrupted:
-		return "{{orange}}"
-	case types.SpecStateAborted:
-		return "{{coral}}"
-	default:
-		return "{{gray}}"
-	}
-}
-
-func (r *DefaultReporter) humanReadableState(state types.SpecState) string {
-	return strings.ToUpper(state.String())
-}
-
-func (r *DefaultReporter) EmitFailure(indent uint, state types.SpecState, failure types.Failure, includeState bool) {
-	highlightColor := r.highlightColorForState(state)
-	if includeState {
-		r.emitBlock(r.fi(indent, highlightColor+"[%s]{{/}}", r.humanReadableState(state)))
-	}
-	r.emitBlock(r.fi(indent, highlightColor+"%s{{/}}", failure.Message))
-	r.emitBlock(r.fi(indent, highlightColor+"In {{bold}}[%s]{{/}}"+highlightColor+" at: {{bold}}%s{{/}}\n", failure.FailureNodeType, failure.Location))
-	if failure.ForwardedPanic != "" {
-		r.emitBlock("\n")
-		r.emitBlock(r.fi(indent, highlightColor+"%s{{/}}", failure.ForwardedPanic))
-	}
-
-	if r.conf.FullTrace || failure.ForwardedPanic != "" {
-		r.emitBlock("\n")
-		r.emitBlock(r.fi(indent, highlightColor+"Full Stack Trace{{/}}"))
-		r.emitBlock(r.fi(indent+1, "%s", failure.Location.FullStackTrace))
-	}
-
-	if !failure.ProgressReport.IsZero() {
-		r.emitBlock("\n")
-		r.emitProgressReport(indent, false, failure.ProgressReport)
-	}
-}
-
 func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
 	failures := report.SpecReports.WithState(types.SpecStateFailureStates)
 	if len(failures) > 0 {
-		r.emitBlock("\n\n")
+		r.emitBlock("\n")
 		if len(failures) > 1 {
 			r.emitBlock(r.f("{{red}}{{bold}}Summarizing %d Failures:{{/}}", len(failures)))
 		} else {
@@ -338,7 +120,7 @@ func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
 			case types.SpecStateInterrupted:
 				highlightColor, heading = "{{orange}}", "[INTERRUPTED]"
 			}
-			locationBlock := r.codeLocationBlock(specReport, highlightColor, true, true)
+			locationBlock := r.codeLocationBlock(specReport, highlightColor, false, true)
 			r.emitBlock(r.fi(1, highlightColor+"%s{{/}} %s", heading, locationBlock))
 		}
 	}
@@ -387,14 +169,271 @@ func (r *DefaultReporter) SuiteDidEnd(report types.Report) {
 	}
 }
 
+func (r *DefaultReporter) WillRun(report types.SpecReport) {
+	v := r.conf.Verbosity()
+	if v.LT(types.VerbosityLevelVerbose) || report.State.Is(types.SpecStatePending|types.SpecStateSkipped) || report.RunningInParallel {
+		return
+	}
+
+	r.emitDelimiter(0)
+	r.emitBlock(r.f(r.codeLocationBlock(report, "{{/}}", v.Is(types.VerbosityLevelVeryVerbose), false)))
+}
+
+func (r *DefaultReporter) DidRun(report types.SpecReport) {
+	v := r.conf.Verbosity()
+	inParallel := report.RunningInParallel
+
+	header := r.specDenoter
+	if report.LeafNodeType.Is(types.NodeTypesForSuiteLevelNodes) {
+		header = fmt.Sprintf("[%s]", report.LeafNodeType)
+	}
+	highlightColor := r.highlightColorForState(report.State)
+
+	// have we already been streaming the timeline?
+	timelineHasBeenStreaming := v.GTE(types.VerbosityLevelVerbose) && !inParallel
+
+	// should we show the timeline?
+	var timeline types.Timeline
+	showTimeline := !timelineHasBeenStreaming && (v.GTE(types.VerbosityLevelVerbose) || report.Failed())
+	if showTimeline {
+		timeline = report.Timeline().WithoutHiddenReportEntries()
+		keepVeryVerboseSpecEvents := v.Is(types.VerbosityLevelVeryVerbose) ||
+			(v.Is(types.VerbosityLevelVerbose) && r.conf.ShowNodeEvents) ||
+			(report.Failed() && r.conf.ShowNodeEvents)
+		if !keepVeryVerboseSpecEvents {
+			timeline = timeline.WithoutVeryVerboseSpecEvents()
+		}
+		if len(timeline) == 0 && report.CapturedGinkgoWriterOutput == "" {
+			// the timeline is completely empty - don't show it
+			showTimeline = false
+		}
+		if v.LT(types.VerbosityLevelVeryVerbose) && report.CapturedGinkgoWriterOutput == "" && len(timeline) > 0 {
+			//if we aren't -vv and the timeline only has a single failure, don't show it as it will appear at the end of the report
+			failure, isFailure := timeline[0].(types.Failure)
+			if isFailure && (len(timeline) == 1 || (len(timeline) == 2 && failure.AdditionalFailure != nil)) {
+				showTimeline = false
+			}
+		}
+	}
+
+	// should we have a separate section for always-visible reports?
+	showSeparateVisibilityAlwaysReportsSection := !timelineHasBeenStreaming && !showTimeline && report.ReportEntries.HasVisibility(types.ReportEntryVisibilityAlways)
+
+	// should we have a separate section for captured stdout/stderr
+	showSeparateStdSection := inParallel && (report.CapturedStdOutErr != "")
+
+	// given all that - do we have any actual content to show? or are we a single denoter in a stream?
+	reportHasContent := v.GTE(types.VerbosityLevelVerbose) || showTimeline || showSeparateVisibilityAlwaysReportsSection || showSeparateStdSection || report.Failed()
+
+	// should we show a runtime?
+	includeRuntime := !report.State.Is(types.SpecStateSkipped|types.SpecStatePending) || (report.State.Is(types.SpecStateSkipped) && report.Failure.Message != "")
+
+	// should we show the codelocation block?
+	showCodeLocation := !timelineHasBeenStreaming || !report.State.Is(types.SpecStatePassed)
+
+	switch report.State {
+	case types.SpecStatePassed:
+		if report.LeafNodeType.Is(types.NodeTypesForSuiteLevelNodes) && !reportHasContent {
+			return
+		}
+		if report.LeafNodeType.Is(types.NodeTypesForSuiteLevelNodes) {
+			header = fmt.Sprintf("%s PASSED", header)
+		}
+		if report.NumAttempts > 1 && report.MaxFlakeAttempts > 1 {
+			header, reportHasContent = fmt.Sprintf("%s [FLAKEY TEST - TOOK %d ATTEMPTS TO PASS]", r.retryDenoter, report.NumAttempts), true
+		}
+	case types.SpecStatePending:
+		header = "P"
+		if v.GT(types.VerbosityLevelSuccinct) {
+			header, reportHasContent = "P [PENDING]", true
+		}
+	case types.SpecStateSkipped:
+		header = "S"
+		if v.GTE(types.VerbosityLevelVerbose) {
+			header = "S [SKIPPED]"
+		}
+	default:
+		header = fmt.Sprintf("%s [%s]", header, r.humanReadableState(report.State))
+		if report.MaxMustPassRepeatedly > 1 {
+			header = fmt.Sprintf("%s DURING REPETITION #%d", header, report.NumAttempts)
+		}
+	}
+
+	// If we have no content to show, jsut emit the header and return
+	if !reportHasContent {
+		r.emit(r.f(highlightColor + header + "{{/}}"))
+		return
+	}
+
+	if includeRuntime {
+		header = r.f("%s [%.3f seconds]", header, report.RunTime.Seconds())
+	}
+
+	// Emit header
+	if !timelineHasBeenStreaming {
+		r.emitDelimiter(0)
+	}
+	r.emitBlock(r.f(highlightColor + header + "{{/}}"))
+	if showCodeLocation {
+		r.emitBlock(r.codeLocationBlock(report, highlightColor, v.Is(types.VerbosityLevelVeryVerbose), false))
+	}
+
+	//Emit Stdout/Stderr Output
+	if showSeparateStdSection {
+		r.emitBlock("\n")
+		r.emitBlock(r.fi(1, "{{gray}}Captured StdOut/StdErr Output >>{{/}}"))
+		r.emitBlock(r.fi(1, "%s", report.CapturedStdOutErr))
+		r.emitBlock(r.fi(1, "{{gray}}<< Captured StdOut/StdErr Output{{/}}"))
+	}
+
+	if showSeparateVisibilityAlwaysReportsSection {
+		r.emitBlock("\n")
+		r.emitBlock(r.fi(1, "{{gray}}Report Entries >>{{/}}"))
+		for _, entry := range report.ReportEntries.WithVisibility(types.ReportEntryVisibilityAlways) {
+			r.emitReportEntry(1, entry)
+		}
+		r.emitBlock(r.fi(1, "{{gray}}<< Report Entries{{/}}"))
+	}
+
+	if showTimeline {
+		r.emitBlock("\n")
+		r.emitBlock(r.fi(1, "{{gray}}Timeline >>{{/}}"))
+		r.emitTimeline(1, report, timeline)
+		r.emitBlock(r.fi(1, "{{gray}}<< Timeline{{/}}"))
+	}
+
+	// Emit Failure Message
+	if !report.Failure.IsZero() && !v.Is(types.VerbosityLevelVeryVerbose) {
+		r.emitBlock("\n")
+		r.emitFailure(1, report.State, report.Failure, true)
+		if len(report.AdditionalFailures) > 0 {
+			r.emitBlock(r.fi(1, "\nThere were {{bold}}{{red}}additional failures{{/}} detected.  To view them in detail run {{bold}}ginkgo -vv{{/}}"))
+		}
+	}
+
+	r.emitDelimiter(0)
+}
+
+func (r *DefaultReporter) highlightColorForState(state types.SpecState) string {
+	switch state {
+	case types.SpecStatePassed:
+		return "{{green}}"
+	case types.SpecStatePending:
+		return "{{yellow}}"
+	case types.SpecStateSkipped:
+		return "{{cyan}}"
+	case types.SpecStateFailed:
+		return "{{red}}"
+	case types.SpecStateTimedout:
+		return "{{orange}}"
+	case types.SpecStatePanicked:
+		return "{{magenta}}"
+	case types.SpecStateInterrupted:
+		return "{{orange}}"
+	case types.SpecStateAborted:
+		return "{{coral}}"
+	default:
+		return "{{gray}}"
+	}
+}
+
+func (r *DefaultReporter) humanReadableState(state types.SpecState) string {
+	return strings.ToUpper(state.String())
+}
+
+func (r *DefaultReporter) emitTimeline(indent uint, report types.SpecReport, timeline types.Timeline) {
+	isVeryVerbose := r.conf.Verbosity().Is(types.VerbosityLevelVeryVerbose)
+	gw := report.CapturedGinkgoWriterOutput
+	cursor := 0
+	for _, entry := range timeline {
+		tl := entry.GetTimelineLocation()
+		if tl.Offset < len(gw) {
+			r.emit(r.fi(indent, "%s", gw[cursor:tl.Offset]))
+			cursor = tl.Offset
+		} else if cursor < len(gw) {
+			r.emit(r.fi(indent, "%s", gw[cursor:]))
+			cursor = len(gw)
+		}
+		switch x := entry.(type) {
+		case types.Failure:
+			if isVeryVerbose {
+				r.emitFailure(indent, report.State, x, false)
+			} else {
+				r.emitShortFailure(indent, report.State, x)
+			}
+		case types.AdditionalFailure:
+			if isVeryVerbose {
+				r.emitFailure(indent, x.State, x.Failure, true)
+			} else {
+				r.emitShortFailure(indent, x.State, x.Failure)
+			}
+		case types.ReportEntry:
+			r.emitReportEntry(indent, x)
+		case types.ProgressReport:
+			r.emitProgressReport(indent, false, x)
+		case types.SpecEvent:
+			if isVeryVerbose || !x.IsOnlyVisibleAtVeryVerbose() || r.conf.ShowNodeEvents {
+				r.emitSpecEvent(indent, x, isVeryVerbose)
+			}
+		}
+	}
+	if cursor < len(gw) {
+		r.emit(r.fi(indent, "%s", gw[cursor:]))
+	}
+}
+
+func (r *DefaultReporter) EmitFailure(state types.SpecState, failure types.Failure) {
+	if r.conf.Verbosity().Is(types.VerbosityLevelVerbose) {
+		r.emitShortFailure(1, state, failure)
+	} else if r.conf.Verbosity().Is(types.VerbosityLevelVeryVerbose) {
+		r.emitFailure(1, state, failure, true)
+	}
+}
+
+func (r *DefaultReporter) emitShortFailure(indent uint, state types.SpecState, failure types.Failure) {
+	r.emitBlock(r.fi(indent, r.highlightColorForState(state)+"[%s]{{/}} in [%s] - %s {{gray}}@ %s{{/}}",
+		r.humanReadableState(state),
+		failure.FailureNodeType,
+		failure.Location,
+		failure.TimelineLocation.Time.Format(types.GINKGO_TIME_FORMAT),
+	))
+}
+
+func (r *DefaultReporter) emitFailure(indent uint, state types.SpecState, failure types.Failure, includeAdditionalFailure bool) {
+	highlightColor := r.highlightColorForState(state)
+	r.emitBlock(r.fi(indent, highlightColor+"[%s] %s{{/}}", r.humanReadableState(state), failure.Message))
+	r.emitBlock(r.fi(indent, highlightColor+"In {{bold}}[%s]{{/}}"+highlightColor+" at: {{bold}}%s{{/}} {{gray}}@ %s{{/}}\n", failure.FailureNodeType, failure.Location, failure.TimelineLocation.Time.Format(types.GINKGO_TIME_FORMAT)))
+	if failure.ForwardedPanic != "" {
+		r.emitBlock("\n")
+		r.emitBlock(r.fi(indent, highlightColor+"%s{{/}}", failure.ForwardedPanic))
+	}
+
+	if r.conf.FullTrace || failure.ForwardedPanic != "" {
+		r.emitBlock("\n")
+		r.emitBlock(r.fi(indent, highlightColor+"Full Stack Trace{{/}}"))
+		r.emitBlock(r.fi(indent+1, "%s", failure.Location.FullStackTrace))
+	}
+
+	if !failure.ProgressReport.IsZero() {
+		r.emitBlock("\n")
+		r.emitProgressReport(indent, false, failure.ProgressReport)
+	}
+
+	if failure.AdditionalFailure != nil && includeAdditionalFailure {
+		r.emitBlock("\n")
+		r.emitFailure(indent, failure.AdditionalFailure.State, failure.AdditionalFailure.Failure, true)
+	}
+}
+
 func (r *DefaultReporter) EmitProgressReport(report types.ProgressReport) {
-	r.emitDelimiter()
+	r.emitDelimiter(1)
 
 	if report.RunningInParallel {
-		r.emit(r.f("{{coral}}Progress Report for Ginkgo Process #{{bold}}%d{{/}}\n", report.ParallelProcess))
+		r.emit(r.fi(1, "{{coral}}Progress Report for Ginkgo Process #{{bold}}%d{{/}}\n", report.ParallelProcess))
 	}
-	r.emitProgressReport(0, true, report)
-	r.emitDelimiter()
+	shouldEmitGW := report.RunningInParallel || r.conf.Verbosity().LT(types.VerbosityLevelVerbose)
+	r.emitProgressReport(1, shouldEmitGW, report)
+	r.emitDelimiter(1)
 }
 
 func (r *DefaultReporter) emitProgressReport(indent uint, emitGinkgoWriterOutput bool, report types.ProgressReport) {
@@ -409,7 +448,7 @@ func (r *DefaultReporter) emitProgressReport(indent uint, emitGinkgoWriterOutput
 			r.emit(" ")
 			subjectIndent = 0
 		}
-		r.emit(r.fi(subjectIndent, "{{bold}}{{orange}}%s{{/}} (Spec Runtime: %s)\n", report.LeafNodeText, report.Time.Sub(report.SpecStartTime).Round(time.Millisecond)))
+		r.emit(r.fi(subjectIndent, "{{bold}}{{orange}}%s{{/}} (Spec Runtime: %s)\n", report.LeafNodeText, report.Time().Sub(report.SpecStartTime).Round(time.Millisecond)))
 		r.emit(r.fi(indent+1, "{{gray}}%s{{/}}\n", report.LeafNodeLocation))
 		indent += 1
 	}
@@ -419,12 +458,12 @@ func (r *DefaultReporter) emitProgressReport(indent uint, emitGinkgoWriterOutput
 			r.emit(r.f(" {{bold}}{{orange}}%s{{/}}", report.CurrentNodeText))
 		}
 
-		r.emit(r.f(" (Node Runtime: %s)\n", report.Time.Sub(report.CurrentNodeStartTime).Round(time.Millisecond)))
+		r.emit(r.f(" (Node Runtime: %s)\n", report.Time().Sub(report.CurrentNodeStartTime).Round(time.Millisecond)))
 		r.emit(r.fi(indent+1, "{{gray}}%s{{/}}\n", report.CurrentNodeLocation))
 		indent += 1
 	}
 	if report.CurrentStepText != "" {
-		r.emit(r.fi(indent, "At {{bold}}{{orange}}[By Step] %s{{/}} (Step Runtime: %s)\n", report.CurrentStepText, report.Time.Sub(report.CurrentStepStartTime).Round(time.Millisecond)))
+		r.emit(r.fi(indent, "At {{bold}}{{orange}}[By Step] %s{{/}} (Step Runtime: %s)\n", report.CurrentStepText, report.Time().Sub(report.CurrentStepStartTime).Round(time.Millisecond)))
 		r.emit(r.fi(indent+1, "{{gray}}%s{{/}}\n", report.CurrentStepLocation))
 		indent += 1
 	}
@@ -433,9 +472,19 @@ func (r *DefaultReporter) emitProgressReport(indent uint, emitGinkgoWriterOutput
 		indent -= 1
 	}
 
-	if emitGinkgoWriterOutput && report.CapturedGinkgoWriterOutput != "" && (report.RunningInParallel || r.conf.Verbosity().LT(types.VerbosityLevelVerbose)) {
+	if emitGinkgoWriterOutput && report.CapturedGinkgoWriterOutput != "" {
 		r.emit("\n")
-		r.emitGinkgoWriterOutput(indent, report.CapturedGinkgoWriterOutput, 10)
+		r.emitBlock(r.fi(indent, "{{gray}}Begin Captured GinkgoWriter Output >>{{/}}"))
+		limit, lines := 10, strings.Split(report.CapturedGinkgoWriterOutput, "\n")
+		if len(lines) <= limit {
+			r.emitBlock(r.fi(indent+1, "%s", report.CapturedGinkgoWriterOutput))
+		} else {
+			r.emitBlock(r.fi(indent+1, "{{gray}}...{{/}}"))
+			for _, line := range lines[len(lines)-limit-1:] {
+				r.emitBlock(r.fi(indent+1, "%s", line))
+			}
+		}
+		r.emitBlock(r.fi(indent, "{{gray}}<< End Captured GinkgoWriter Output{{/}}"))
 	}
 
 	if !report.SpecGoroutine().IsZero() {
@@ -471,22 +520,48 @@ func (r *DefaultReporter) emitProgressReport(indent uint, emitGinkgoWriterOutput
 	}
 }
 
-func (r *DefaultReporter) emitGinkgoWriterOutput(indent uint, output string, limit int) {
-	r.emitBlock(r.fi(indent, "{{gray}}Begin Captured GinkgoWriter Output >>{{/}}"))
-	if limit == 0 {
-		r.emitBlock(r.fi(indent+1, "%s", output))
-	} else {
-		lines := strings.Split(output, "\n")
-		if len(lines) <= limit {
-			r.emitBlock(r.fi(indent+1, "%s", output))
-		} else {
-			r.emitBlock(r.fi(indent+1, "{{gray}}...{{/}}"))
-			for _, line := range lines[len(lines)-limit-1:] {
-				r.emitBlock(r.fi(indent+1, "%s", line))
-			}
-		}
+func (r *DefaultReporter) EmitReportEntry(entry types.ReportEntry) {
+	if r.conf.Verbosity().LT(types.VerbosityLevelVerbose) || entry.Visibility == types.ReportEntryVisibilityNever {
+		return
 	}
-	r.emitBlock(r.fi(indent, "{{gray}}<< End Captured GinkgoWriter Output{{/}}"))
+	r.emitReportEntry(1, entry)
+}
+
+func (r *DefaultReporter) emitReportEntry(indent uint, entry types.ReportEntry) {
+	r.emitBlock(r.fi(indent, "{{bold}}"+entry.Name+"{{gray}} - %s @ %s{{/}}", entry.Location, entry.Time.Format(types.GINKGO_TIME_FORMAT)))
+	if representation := entry.StringRepresentation(); representation != "" {
+		r.emitBlock(r.fi(indent+1, representation))
+	}
+}
+
+func (r *DefaultReporter) EmitSpecEvent(event types.SpecEvent) {
+	v := r.conf.Verbosity()
+	if v.Is(types.VerbosityLevelVeryVerbose) || (v.Is(types.VerbosityLevelVerbose) && (r.conf.ShowNodeEvents || !event.IsOnlyVisibleAtVeryVerbose())) {
+		r.emitSpecEvent(1, event, r.conf.Verbosity().Is(types.VerbosityLevelVeryVerbose))
+	}
+}
+
+func (r *DefaultReporter) emitSpecEvent(indent uint, event types.SpecEvent, includeLocation bool) {
+	location := ""
+	if includeLocation {
+		location = fmt.Sprintf("- %s ", event.CodeLocation.String())
+	}
+	switch event.SpecEventType {
+	case types.SpecEventInvalid:
+		return
+	case types.SpecEventByStart:
+		r.emitBlock(r.fi(indent, "{{bold}}STEP:{{/}} %s {{gray}}%s@ %s{{/}}", event.Message, location, event.TimelineLocation.Time.Format(types.GINKGO_TIME_FORMAT)))
+	case types.SpecEventByEnd:
+		r.emitBlock(r.fi(indent, "{{bold}}END STEP:{{/}} %s {{gray}}%s@ %s (%s){{/}}", event.Message, location, event.TimelineLocation.Time.Format(types.GINKGO_TIME_FORMAT), event.Duration.Round(time.Millisecond)))
+	case types.SpecEventNodeStart:
+		r.emitBlock(r.fi(indent, "> Enter {{bold}}[%s]{{/}} %s {{gray}}%s@ %s{{/}}", event.NodeType.String(), event.Message, location, event.TimelineLocation.Time.Format(types.GINKGO_TIME_FORMAT)))
+	case types.SpecEventNodeEnd:
+		r.emitBlock(r.fi(indent, "< Exit {{bold}}[%s]{{/}} %s {{gray}}%s@ %s (%s){{/}}", event.NodeType.String(), event.Message, location, event.TimelineLocation.Time.Format(types.GINKGO_TIME_FORMAT), event.Duration.Round(time.Millisecond)))
+	case types.SpecEventSpecRepeat:
+		r.emitBlock(r.fi(indent, "\n{{bold}}Attempt #%d {{green}}Passed{{/}}{{bold}}.  Repeating %s{{/}} {{gray}}@ %s{{/}}\n\n", event.Attempt, r.retryDenoter, event.TimelineLocation.Time.Format(types.GINKGO_TIME_FORMAT)))
+	case types.SpecEventSpecRetry:
+		r.emitBlock(r.fi(indent, "\n{{bold}}Attempt #%d {{red}}Failed{{/}}{{bold}}.  Retrying %s{{/}} {{gray}}@ %s{{/}}\n\n", event.Attempt, r.retryDenoter, event.TimelineLocation.Time.Format(types.GINKGO_TIME_FORMAT)))
+	}
 }
 
 func (r *DefaultReporter) emitGoroutines(indent uint, goroutines ...types.Goroutine) {
@@ -563,11 +638,11 @@ func (r *DefaultReporter) emitBlock(s string) {
 	}
 }
 
-func (r *DefaultReporter) emitDelimiter() {
+func (r *DefaultReporter) emitDelimiter(indent uint) {
 	if r.lastEmissionWasDelimiter {
 		return
 	}
-	r.emitBlock(r.f("{{gray}}%s{{/}}", strings.Repeat("-", 30)))
+	r.emitBlock(r.fi(indent, "{{gray}}%s{{/}}", strings.Repeat("-", 30)))
 	r.lastEmissionWasDelimiter = true
 }
 
@@ -584,13 +659,14 @@ func (r *DefaultReporter) cycleJoin(elements []string, joiner string) string {
 	return r.formatter.CycleJoin(elements, joiner, []string{"{{/}}", "{{gray}}"})
 }
 
-func (r *DefaultReporter) codeLocationBlock(report types.SpecReport, highlightColor string, succinct bool, usePreciseFailureLocation bool) string {
+func (r *DefaultReporter) codeLocationBlock(report types.SpecReport, highlightColor string, veryVerbose bool, usePreciseFailureLocation bool) string {
 	texts, locations, labels := []string{}, []types.CodeLocation{}, [][]string{}
 	texts, locations, labels = append(texts, report.ContainerHierarchyTexts...), append(locations, report.ContainerHierarchyLocations...), append(labels, report.ContainerHierarchyLabels...)
+
 	if report.LeafNodeType.Is(types.NodeTypesForSuiteLevelNodes) {
 		texts = append(texts, r.f("[%s] %s", report.LeafNodeType, report.LeafNodeText))
 	} else {
-		texts = append(texts, report.LeafNodeText)
+		texts = append(texts, r.f(report.LeafNodeText))
 	}
 	labels = append(labels, report.LeafNodeLabels)
 	locations = append(locations, report.LeafNodeLocation)
@@ -600,24 +676,58 @@ func (r *DefaultReporter) codeLocationBlock(report types.SpecReport, highlightCo
 		failureLocation = report.Failure.Location
 	}
 
+	highlightIndex := -1
 	switch report.Failure.FailureNodeContext {
 	case types.FailureNodeAtTopLevel:
-		texts = append([]string{r.f(highlightColor+"{{bold}}TOP-LEVEL [%s]{{/}}", report.Failure.FailureNodeType)}, texts...)
+		texts = append([]string{fmt.Sprintf("TOP-LEVEL [%s]", report.Failure.FailureNodeType)}, texts...)
 		locations = append([]types.CodeLocation{failureLocation}, locations...)
 		labels = append([][]string{{}}, labels...)
+		highlightIndex = 0
 	case types.FailureNodeInContainer:
 		i := report.Failure.FailureNodeContainerIndex
-		texts[i] = r.f(highlightColor+"{{bold}}%s [%s]{{/}}", texts[i], report.Failure.FailureNodeType)
+		texts[i] = fmt.Sprintf("%s [%s]", texts[i], report.Failure.FailureNodeType)
 		locations[i] = failureLocation
+		highlightIndex = i
 	case types.FailureNodeIsLeafNode:
 		i := len(texts) - 1
-		texts[i] = r.f(highlightColor+"{{bold}}[%s] %s{{/}}", report.LeafNodeType, report.LeafNodeText)
+		texts[i] = fmt.Sprintf("[%s] %s", report.LeafNodeType, report.LeafNodeText)
 		locations[i] = failureLocation
+		highlightIndex = i
+	default:
+		//there is no failure, so we highlight the leaf ndoe
+		highlightIndex = len(texts) - 1
 	}
 
 	out := ""
-	if succinct {
-		out += r.f("%s", r.cycleJoin(texts, " "))
+	if veryVerbose {
+		for i := range texts {
+			if i == highlightIndex {
+				out += r.fi(uint(i), highlightColor+"{{bold}}%s{{/}}", texts[i])
+			} else {
+				out += r.fi(uint(i), "%s", texts[i])
+			}
+			if len(labels[i]) > 0 {
+				out += r.f(" {{coral}}[%s]{{/}}", strings.Join(labels[i], ", "))
+			}
+			out += "\n"
+			out += r.fi(uint(i), "{{gray}}%s{{/}}\n", locations[i])
+		}
+	} else {
+		for i := range texts {
+			style := "{{/}}"
+			if i%2 == 1 {
+				style = "{{gray}}"
+			}
+			if i == highlightIndex {
+				style = highlightColor + "{{bold}}"
+			}
+			out += r.f(style+"%s", texts[i])
+			if i < len(texts)-1 {
+				out += " "
+			} else {
+				out += r.f("{{/}}")
+			}
+		}
 		flattenedLabels := report.Labels()
 		if len(flattenedLabels) > 0 {
 			out += r.f(" {{coral}}[%s]{{/}}", strings.Join(flattenedLabels, ", "))
@@ -626,17 +736,15 @@ func (r *DefaultReporter) codeLocationBlock(report types.SpecReport, highlightCo
 		if usePreciseFailureLocation {
 			out += r.f("{{gray}}%s{{/}}", failureLocation)
 		} else {
-			out += r.f("{{gray}}%s{{/}}", locations[len(locations)-1])
-		}
-	} else {
-		for i := range texts {
-			out += r.fi(uint(i), "%s", texts[i])
-			if len(labels[i]) > 0 {
-				out += r.f(" {{coral}}[%s]{{/}}", strings.Join(labels[i], ", "))
+			leafLocation := locations[len(locations)-1]
+			if (report.Failure.FailureNodeLocation != types.CodeLocation{}) && (report.Failure.FailureNodeLocation != leafLocation) {
+				out += r.fi(1, highlightColor+"[%s]{{/}} {{gray}}%s{{/}}\n", report.Failure.FailureNodeType, report.Failure.FailureNodeLocation)
+				out += r.fi(1, "{{gray}}[%s] %s{{/}}", report.LeafNodeType, leafLocation)
+			} else {
+				out += r.f("{{gray}}%s{{/}}", leafLocation)
 			}
-			out += "\n"
-			out += r.fi(uint(i), "{{gray}}%s{{/}}\n", locations[i])
 		}
+
 	}
 	return out
 }

--- a/vendor/github.com/onsi/ginkgo/v2/reporters/deprecated_reporter.go
+++ b/vendor/github.com/onsi/ginkgo/v2/reporters/deprecated_reporter.go
@@ -35,7 +35,7 @@ func ReportViaDeprecatedReporter(reporter DeprecatedReporter, report types.Repor
 		FailOnPending:     report.SuiteConfig.FailOnPending,
 		FailFast:          report.SuiteConfig.FailFast,
 		FlakeAttempts:     report.SuiteConfig.FlakeAttempts,
-		EmitSpecProgress:  report.SuiteConfig.EmitSpecProgress,
+		EmitSpecProgress:  false,
 		DryRun:            report.SuiteConfig.DryRun,
 		ParallelNode:      report.SuiteConfig.ParallelProcess,
 		ParallelTotal:     report.SuiteConfig.ParallelTotal,

--- a/vendor/github.com/onsi/ginkgo/v2/reporters/junit_report.go
+++ b/vendor/github.com/onsi/ginkgo/v2/reporters/junit_report.go
@@ -15,11 +15,22 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/onsi/ginkgo/v2/config"
 	"github.com/onsi/ginkgo/v2/types"
 )
+
+type JunitReportConfig struct {
+	// Spec States for which no timeline should be emitted for system-err
+	// set this to types.SpecStatePassed|types.SpecStateSkipped|types.SpecStatePending to only match failing specs
+	OmitTimelinesForSpecState types.SpecState
+
+	// Enable OmitFailureMessageAttr to prevent failure messages appearing in the "message" attribute of the Failure and Error tags
+	OmitFailureMessageAttr bool
+
+	//Enable OmitCapturedStdOutErr to prevent captured stdout/stderr appearing in system-out
+	OmitCapturedStdOutErr bool
+}
 
 type JUnitTestSuites struct {
 	XMLName xml.Name `xml:"testsuites"`
@@ -128,6 +139,10 @@ type JUnitFailure struct {
 }
 
 func GenerateJUnitReport(report types.Report, dst string) error {
+	return GenerateJUnitReportWithConfig(report, dst, JunitReportConfig{})
+}
+
+func GenerateJUnitReportWithConfig(report types.Report, dst string, config JunitReportConfig) error {
 	suite := JUnitTestSuite{
 		Name:      report.SuiteDescription,
 		Package:   report.SuitePath,
@@ -149,7 +164,6 @@ func GenerateJUnitReport(report types.Report, dst string) error {
 				{"FailOnPending", fmt.Sprintf("%t", report.SuiteConfig.FailOnPending)},
 				{"FailFast", fmt.Sprintf("%t", report.SuiteConfig.FailFast)},
 				{"FlakeAttempts", fmt.Sprintf("%d", report.SuiteConfig.FlakeAttempts)},
-				{"EmitSpecProgress", fmt.Sprintf("%t", report.SuiteConfig.EmitSpecProgress)},
 				{"DryRun", fmt.Sprintf("%t", report.SuiteConfig.DryRun)},
 				{"ParallelTotal", fmt.Sprintf("%d", report.SuiteConfig.ParallelTotal)},
 				{"OutputInterceptorMode", report.SuiteConfig.OutputInterceptorMode},
@@ -171,8 +185,12 @@ func GenerateJUnitReport(report types.Report, dst string) error {
 			Classname: report.SuiteDescription,
 			Status:    spec.State.String(),
 			Time:      spec.RunTime.Seconds(),
-			SystemOut: systemOutForUnstructuredReporters(spec),
-			SystemErr: systemErrForUnstructuredReporters(spec),
+		}
+		if !spec.State.Is(config.OmitTimelinesForSpecState) {
+			test.SystemErr = systemErrForUnstructuredReporters(spec)
+		}
+		if !config.OmitCapturedStdOutErr {
+			test.SystemOut = systemOutForUnstructuredReporters(spec)
 		}
 		suite.Tests += 1
 
@@ -193,12 +211,18 @@ func GenerateJUnitReport(report types.Report, dst string) error {
 				Type:        "failed",
 				Description: failureDescriptionForUnstructuredReporters(spec),
 			}
+			if config.OmitFailureMessageAttr {
+				test.Failure.Message = ""
+			}
 			suite.Failures += 1
 		case types.SpecStateTimedout:
 			test.Failure = &JUnitFailure{
 				Message:     spec.Failure.Message,
 				Type:        "timedout",
 				Description: failureDescriptionForUnstructuredReporters(spec),
+			}
+			if config.OmitFailureMessageAttr {
+				test.Failure.Message = ""
 			}
 			suite.Failures += 1
 		case types.SpecStateInterrupted:
@@ -207,6 +231,9 @@ func GenerateJUnitReport(report types.Report, dst string) error {
 				Type:        "interrupted",
 				Description: failureDescriptionForUnstructuredReporters(spec),
 			}
+			if config.OmitFailureMessageAttr {
+				test.Error.Message = ""
+			}
 			suite.Errors += 1
 		case types.SpecStateAborted:
 			test.Failure = &JUnitFailure{
@@ -214,12 +241,18 @@ func GenerateJUnitReport(report types.Report, dst string) error {
 				Type:        "aborted",
 				Description: failureDescriptionForUnstructuredReporters(spec),
 			}
+			if config.OmitFailureMessageAttr {
+				test.Failure.Message = ""
+			}
 			suite.Errors += 1
 		case types.SpecStatePanicked:
 			test.Error = &JUnitError{
 				Message:     spec.Failure.ForwardedPanic,
 				Type:        "panicked",
 				Description: failureDescriptionForUnstructuredReporters(spec),
+			}
+			if config.OmitFailureMessageAttr {
+				test.Error.Message = ""
 			}
 			suite.Errors += 1
 		}
@@ -287,63 +320,21 @@ func MergeAndCleanupJUnitReports(sources []string, dst string) ([]string, error)
 
 func failureDescriptionForUnstructuredReporters(spec types.SpecReport) string {
 	out := &strings.Builder{}
-	out.WriteString(spec.Failure.Location.String() + "\n")
-	out.WriteString(spec.Failure.Location.FullStackTrace)
-	if !spec.Failure.ProgressReport.IsZero() {
-		out.WriteString("\n")
-		NewDefaultReporter(types.ReporterConfig{NoColor: true}, out).EmitProgressReport(spec.Failure.ProgressReport)
-	}
+	NewDefaultReporter(types.ReporterConfig{NoColor: true, VeryVerbose: true}, out).emitFailure(0, spec.State, spec.Failure, true)
 	if len(spec.AdditionalFailures) > 0 {
-		out.WriteString("\nThere were additional failures detected after the initial failure:\n")
-		for i, additionalFailure := range spec.AdditionalFailures {
-			NewDefaultReporter(types.ReporterConfig{NoColor: true}, out).EmitFailure(0, additionalFailure.State, additionalFailure.Failure, true)
-			if i < len(spec.AdditionalFailures)-1 {
-				out.WriteString("----------\n")
-			}
-		}
+		out.WriteString("\nThere were additional failures detected after the initial failure. These are visible in the timeline\n")
 	}
 	return out.String()
 }
 
 func systemErrForUnstructuredReporters(spec types.SpecReport) string {
 	out := &strings.Builder{}
-	gw := spec.CapturedGinkgoWriterOutput
-	cursor := 0
-	for _, pr := range spec.ProgressReports {
-		if cursor < pr.GinkgoWriterOffset {
-			if pr.GinkgoWriterOffset < len(gw) {
-				out.WriteString(gw[cursor:pr.GinkgoWriterOffset])
-				cursor = pr.GinkgoWriterOffset
-			} else if cursor < len(gw) {
-				out.WriteString(gw[cursor:])
-				cursor = len(gw)
-			}
-		}
-		NewDefaultReporter(types.ReporterConfig{NoColor: true}, out).EmitProgressReport(pr)
-	}
-
-	if cursor < len(gw) {
-		out.WriteString(gw[cursor:])
-	}
-
+	NewDefaultReporter(types.ReporterConfig{NoColor: true, VeryVerbose: true}, out).emitTimeline(0, spec, spec.Timeline())
 	return out.String()
 }
 
 func systemOutForUnstructuredReporters(spec types.SpecReport) string {
-	systemOut := spec.CapturedStdOutErr
-	if len(spec.ReportEntries) > 0 {
-		systemOut += "\nReport Entries:\n"
-		for i, entry := range spec.ReportEntries {
-			systemOut += fmt.Sprintf("%s\n%s\n%s\n", entry.Name, entry.Location, entry.Time.Format(time.RFC3339Nano))
-			if representation := entry.StringRepresentation(); representation != "" {
-				systemOut += representation + "\n"
-			}
-			if i+1 < len(spec.ReportEntries) {
-				systemOut += "--\n"
-			}
-		}
-	}
-	return systemOut
+	return spec.CapturedStdOutErr
 }
 
 // Deprecated JUnitReporter (so folks can still compile their suites)

--- a/vendor/github.com/onsi/ginkgo/v2/reporters/reporter.go
+++ b/vendor/github.com/onsi/ginkgo/v2/reporters/reporter.go
@@ -9,13 +9,21 @@ type Reporter interface {
 	WillRun(report types.SpecReport)
 	DidRun(report types.SpecReport)
 	SuiteDidEnd(report types.Report)
+
+	//Timeline emission
+	EmitFailure(state types.SpecState, failure types.Failure)
 	EmitProgressReport(progressReport types.ProgressReport)
+	EmitReportEntry(entry types.ReportEntry)
+	EmitSpecEvent(event types.SpecEvent)
 }
 
 type NoopReporter struct{}
 
-func (n NoopReporter) SuiteWillBegin(report types.Report)                     {}
-func (n NoopReporter) WillRun(report types.SpecReport)                        {}
-func (n NoopReporter) DidRun(report types.SpecReport)                         {}
-func (n NoopReporter) SuiteDidEnd(report types.Report)                        {}
-func (n NoopReporter) EmitProgressReport(progressReport types.ProgressReport) {}
+func (n NoopReporter) SuiteWillBegin(report types.Report)                       {}
+func (n NoopReporter) WillRun(report types.SpecReport)                          {}
+func (n NoopReporter) DidRun(report types.SpecReport)                           {}
+func (n NoopReporter) SuiteDidEnd(report types.Report)                          {}
+func (n NoopReporter) EmitFailure(state types.SpecState, failure types.Failure) {}
+func (n NoopReporter) EmitProgressReport(progressReport types.ProgressReport)   {}
+func (n NoopReporter) EmitReportEntry(entry types.ReportEntry)                  {}
+func (n NoopReporter) EmitSpecEvent(event types.SpecEvent)                      {}

--- a/vendor/github.com/onsi/ginkgo/v2/types/code_location.go
+++ b/vendor/github.com/onsi/ginkgo/v2/types/code_location.go
@@ -1,4 +1,5 @@
 package types
+
 import (
 	"fmt"
 	"os"

--- a/vendor/github.com/onsi/ginkgo/v2/types/config.go
+++ b/vendor/github.com/onsi/ginkgo/v2/types/config.go
@@ -26,7 +26,6 @@ type SuiteConfig struct {
 	FailOnPending         bool
 	FailFast              bool
 	FlakeAttempts         int
-	EmitSpecProgress      bool
 	DryRun                bool
 	PollProgressAfter     time.Duration
 	PollProgressInterval  time.Duration
@@ -81,13 +80,12 @@ func (vl VerbosityLevel) LT(comp VerbosityLevel) bool {
 
 // Configuration for Ginkgo's reporter
 type ReporterConfig struct {
-	NoColor                bool
-	SlowSpecThreshold      time.Duration
-	Succinct               bool
-	Verbose                bool
-	VeryVerbose            bool
-	FullTrace              bool
-	AlwaysEmitGinkgoWriter bool
+	NoColor        bool
+	Succinct       bool
+	Verbose        bool
+	VeryVerbose    bool
+	FullTrace      bool
+	ShowNodeEvents bool
 
 	JSONReport     string
 	JUnitReport    string
@@ -110,9 +108,7 @@ func (rc ReporterConfig) WillGenerateReport() bool {
 }
 
 func NewDefaultReporterConfig() ReporterConfig {
-	return ReporterConfig{
-		SlowSpecThreshold: 5 * time.Second,
-	}
+	return ReporterConfig{}
 }
 
 // Configuration for the Ginkgo CLI
@@ -235,6 +231,9 @@ type deprecatedConfig struct {
 	SlowSpecThresholdWithFLoatUnits float64
 	Stream                          bool
 	Notify                          bool
+	EmitSpecProgress                bool
+	SlowSpecThreshold               time.Duration
+	AlwaysEmitGinkgoWriter          bool
 }
 
 // Flags
@@ -275,8 +274,6 @@ var SuiteConfigFlags = GinkgoFlags{
 
 	{KeyPath: "S.DryRun", Name: "dry-run", SectionKey: "debug", DeprecatedName: "dryRun", DeprecatedDocLink: "changed-command-line-flags",
 		Usage: "If set, ginkgo will walk the test hierarchy without actually running anything.  Best paired with -v."},
-	{KeyPath: "S.EmitSpecProgress", Name: "progress", SectionKey: "debug",
-		Usage: "If set, ginkgo will emit progress information as each spec runs to the GinkgoWriter."},
 	{KeyPath: "S.PollProgressAfter", Name: "poll-progress-after", SectionKey: "debug", UsageDefaultValue: "0",
 		Usage: "Emit node progress reports periodically if node hasn't completed after this duration."},
 	{KeyPath: "S.PollProgressInterval", Name: "poll-progress-interval", SectionKey: "debug", UsageDefaultValue: "10s",
@@ -303,6 +300,8 @@ var SuiteConfigFlags = GinkgoFlags{
 
 	{KeyPath: "D.RegexScansFilePath", DeprecatedName: "regexScansFilePath", DeprecatedDocLink: "removed--regexscansfilepath", DeprecatedVersion: "2.0.0"},
 	{KeyPath: "D.DebugParallel", DeprecatedName: "debug", DeprecatedDocLink: "removed--debug", DeprecatedVersion: "2.0.0"},
+	{KeyPath: "D.EmitSpecProgress", DeprecatedName: "progress", SectionKey: "debug",
+		DeprecatedVersion: "2.5.0", Usage: ".  The funcitonality provided by --progress was confusing and is no longer needed.  Use --show-node-events instead to see node entry and exit events included in the timeline of failed and verbose specs.  Or you can run with -vv to always see all node events.  Lastly, --poll-progress-after and the PollProgressAfter decorator now provide a better mechanism for debugging specs that tend to get stuck."},
 }
 
 // ParallelConfigFlags provides flags for the Ginkgo test process (not the CLI)
@@ -319,8 +318,6 @@ var ParallelConfigFlags = GinkgoFlags{
 var ReporterConfigFlags = GinkgoFlags{
 	{KeyPath: "R.NoColor", Name: "no-color", SectionKey: "output", DeprecatedName: "noColor", DeprecatedDocLink: "changed-command-line-flags",
 		Usage: "If set, suppress color output in default reporter."},
-	{KeyPath: "R.SlowSpecThreshold", Name: "slow-spec-threshold", SectionKey: "output", UsageArgument: "duration", UsageDefaultValue: "5s",
-		Usage: "Specs that take longer to run than this threshold are flagged as slow by the default reporter."},
 	{KeyPath: "R.Verbose", Name: "v", SectionKey: "output",
 		Usage: "If set, emits more output including GinkgoWriter contents."},
 	{KeyPath: "R.VeryVerbose", Name: "vv", SectionKey: "output",
@@ -329,8 +326,8 @@ var ReporterConfigFlags = GinkgoFlags{
 		Usage: "If set, default reporter prints out a very succinct report"},
 	{KeyPath: "R.FullTrace", Name: "trace", SectionKey: "output",
 		Usage: "If set, default reporter prints out the full stack trace when a failure occurs"},
-	{KeyPath: "R.AlwaysEmitGinkgoWriter", Name: "always-emit-ginkgo-writer", SectionKey: "output", DeprecatedName: "reportPassed", DeprecatedDocLink: "renamed--reportpassed",
-		Usage: "If set, default reporter prints out captured output of passed tests."},
+	{KeyPath: "R.ShowNodeEvents", Name: "show-node-events", SectionKey: "output",
+		Usage: "If set, default reporter prints node > Enter and < Exit events when specs fail"},
 
 	{KeyPath: "R.JSONReport", Name: "json-report", UsageArgument: "filename.json", SectionKey: "output",
 		Usage: "If set, Ginkgo will generate a JSON-formatted test report at the specified location."},
@@ -343,6 +340,8 @@ var ReporterConfigFlags = GinkgoFlags{
 		Usage: "use --slow-spec-threshold instead and pass in a duration string (e.g. '5s', not '5.0')"},
 	{KeyPath: "D.NoisyPendings", DeprecatedName: "noisyPendings", DeprecatedDocLink: "removed--noisypendings-and--noisyskippings", DeprecatedVersion: "2.0.0"},
 	{KeyPath: "D.NoisySkippings", DeprecatedName: "noisySkippings", DeprecatedDocLink: "removed--noisypendings-and--noisyskippings", DeprecatedVersion: "2.0.0"},
+	{KeyPath: "D.SlowSpecThreshold", DeprecatedName: "slow-spec-threshold", SectionKey: "output", Usage: "--slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo.  This feature has proved to be more noisy than useful.  You can use --poll-progress-after, instead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.", DeprecatedVersion: "2.5.0"},
+	{KeyPath: "D.AlwaysEmitGinkgoWriter", DeprecatedName: "always-emit-ginkgo-writer", SectionKey: "output", Usage: " - use -v instead, or one of Ginkgo's machine-readable report formats to get GinkgoWriter output for passing specs."},
 }
 
 // BuildTestSuiteFlagSet attaches to the CommandLine flagset and provides flags for the Ginkgo test process

--- a/vendor/github.com/onsi/ginkgo/v2/types/deprecation_support.go
+++ b/vendor/github.com/onsi/ginkgo/v2/types/deprecation_support.go
@@ -83,6 +83,13 @@ func (d deprecations) Nodot() Deprecation {
 	}
 }
 
+func (d deprecations) SuppressProgressReporting() Deprecation {
+	return Deprecation{
+		Message: "Improvements to how reporters emit timeline information means that SuppressProgressReporting is no longer necessary and has been deprecated.",
+		Version: "2.5.0",
+	}
+}
+
 type DeprecationTracker struct {
 	deprecations map[Deprecation][]CodeLocation
 	lock         *sync.Mutex

--- a/vendor/github.com/onsi/ginkgo/v2/types/report_entry.go
+++ b/vendor/github.com/onsi/ginkgo/v2/types/report_entry.go
@@ -6,8 +6,8 @@ import (
 	"time"
 )
 
-//ReportEntryValue wraps a report entry's value ensuring it can be encoded and decoded safely into reports
-//and across the network connection when running in parallel
+// ReportEntryValue wraps a report entry's value ensuring it can be encoded and decoded safely into reports
+// and across the network connection when running in parallel
 type ReportEntryValue struct {
 	raw            interface{} //unexported to prevent gob from freaking out about unregistered structs
 	AsJSON         string
@@ -85,10 +85,12 @@ func (rev *ReportEntryValue) GobDecode(data []byte) error {
 type ReportEntry struct {
 	// Visibility captures the visibility policy for this ReportEntry
 	Visibility ReportEntryVisibility
-	// Time captures the time the AddReportEntry was called
-	Time time.Time
 	// Location captures the location of the AddReportEntry call
 	Location CodeLocation
+
+	Time             time.Time //need this for backwards compatibility
+	TimelineLocation TimelineLocation
+
 	// Name captures the name of this report
 	Name string
 	// Value captures the (optional) object passed into AddReportEntry - this can be
@@ -120,7 +122,9 @@ func (entry ReportEntry) GetRawValue() interface{} {
 	return entry.Value.GetRawValue()
 }
 
-
+func (entry ReportEntry) GetTimelineLocation() TimelineLocation {
+	return entry.TimelineLocation
+}
 
 type ReportEntries []ReportEntry
 

--- a/vendor/github.com/onsi/ginkgo/v2/types/types.go
+++ b/vendor/github.com/onsi/ginkgo/v2/types/types.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -59,16 +61,16 @@ type Report struct {
 	SpecReports SpecReports
 }
 
-//PreRunStats contains a set of stats captured before the test run begins.  This is primarily used
-//by Ginkgo's reporter to tell the user how many specs are in the current suite (PreRunStats.TotalSpecs)
-//and how many it intends to run (PreRunStats.SpecsThatWillRun) after applying any relevant focus or skip filters.
+// PreRunStats contains a set of stats captured before the test run begins.  This is primarily used
+// by Ginkgo's reporter to tell the user how many specs are in the current suite (PreRunStats.TotalSpecs)
+// and how many it intends to run (PreRunStats.SpecsThatWillRun) after applying any relevant focus or skip filters.
 type PreRunStats struct {
 	TotalSpecs       int
 	SpecsThatWillRun int
 }
 
-//Add is used by Ginkgo's parallel aggregation mechanisms to combine test run reports form individual parallel processes
-//to form a complete final report.
+// Add is used by Ginkgo's parallel aggregation mechanisms to combine test run reports form individual parallel processes
+// to form a complete final report.
 func (report Report) Add(other Report) Report {
 	report.SuiteSucceeded = report.SuiteSucceeded && other.SuiteSucceeded
 
@@ -147,6 +149,9 @@ type SpecReport struct {
 	// ParallelProcess captures the parallel process that this spec ran on
 	ParallelProcess int
 
+	// RunningInParallel captures whether this spec is part of a suite that ran in parallel
+	RunningInParallel bool
+
 	//Failure is populated if a spec has failed, panicked, been interrupted, or skipped by the user (e.g. calling Skip())
 	//It includes detailed information about the Failure
 	Failure Failure
@@ -178,6 +183,9 @@ type SpecReport struct {
 
 	// AdditionalFailures contains any failures that occurred after the initial spec failure.  These typically occur in cleanup nodes after the initial failure and are only emitted when running in verbose mode.
 	AdditionalFailures []AdditionalFailure
+
+	// SpecEvents capture additional events that occur during the spec run
+	SpecEvents SpecEvents
 }
 
 func (report SpecReport) MarshalJSON() ([]byte, error) {
@@ -204,6 +212,7 @@ func (report SpecReport) MarshalJSON() ([]byte, error) {
 		ReportEntries               ReportEntries       `json:",omitempty"`
 		ProgressReports             []ProgressReport    `json:",omitempty"`
 		AdditionalFailures          []AdditionalFailure `json:",omitempty"`
+		SpecEvents                  SpecEvents          `json:",omitempty"`
 	}{
 		ContainerHierarchyTexts:     report.ContainerHierarchyTexts,
 		ContainerHierarchyLocations: report.ContainerHierarchyLocations,
@@ -238,6 +247,9 @@ func (report SpecReport) MarshalJSON() ([]byte, error) {
 	if len(report.AdditionalFailures) > 0 {
 		out.AdditionalFailures = report.AdditionalFailures
 	}
+	if len(report.SpecEvents) > 0 {
+		out.SpecEvents = report.SpecEvents
+	}
 
 	return json.Marshal(out)
 }
@@ -255,13 +267,13 @@ func (report SpecReport) CombinedOutput() string {
 	return report.CapturedStdOutErr + "\n" + report.CapturedGinkgoWriterOutput
 }
 
-//Failed returns true if report.State is one of the SpecStateFailureStates
+// Failed returns true if report.State is one of the SpecStateFailureStates
 // (SpecStateFailed, SpecStatePanicked, SpecStateinterrupted, SpecStateAborted)
 func (report SpecReport) Failed() bool {
 	return report.State.Is(SpecStateFailureStates)
 }
 
-//FullText returns a concatenation of all the report.ContainerHierarchyTexts and report.LeafNodeText
+// FullText returns a concatenation of all the report.ContainerHierarchyTexts and report.LeafNodeText
 func (report SpecReport) FullText() string {
 	texts := []string{}
 	texts = append(texts, report.ContainerHierarchyTexts...)
@@ -271,7 +283,7 @@ func (report SpecReport) FullText() string {
 	return strings.Join(texts, " ")
 }
 
-//Labels returns a deduped set of all the spec's Labels.
+// Labels returns a deduped set of all the spec's Labels.
 func (report SpecReport) Labels() []string {
 	out := []string{}
 	seen := map[string]bool{}
@@ -293,7 +305,7 @@ func (report SpecReport) Labels() []string {
 	return out
 }
 
-//MatchesLabelFilter returns true if the spec satisfies the passed in label filter query
+// MatchesLabelFilter returns true if the spec satisfies the passed in label filter query
 func (report SpecReport) MatchesLabelFilter(query string) (bool, error) {
 	filter, err := ParseLabelFilter(query)
 	if err != nil {
@@ -302,29 +314,54 @@ func (report SpecReport) MatchesLabelFilter(query string) (bool, error) {
 	return filter(report.Labels()), nil
 }
 
-//FileName() returns the name of the file containing the spec
+// FileName() returns the name of the file containing the spec
 func (report SpecReport) FileName() string {
 	return report.LeafNodeLocation.FileName
 }
 
-//LineNumber() returns the line number of the leaf node
+// LineNumber() returns the line number of the leaf node
 func (report SpecReport) LineNumber() int {
 	return report.LeafNodeLocation.LineNumber
 }
 
-//FailureMessage() returns the failure message (or empty string if the test hasn't failed)
+// FailureMessage() returns the failure message (or empty string if the test hasn't failed)
 func (report SpecReport) FailureMessage() string {
 	return report.Failure.Message
 }
 
-//FailureLocation() returns the location of the failure (or an empty CodeLocation if the test hasn't failed)
+// FailureLocation() returns the location of the failure (or an empty CodeLocation if the test hasn't failed)
 func (report SpecReport) FailureLocation() CodeLocation {
 	return report.Failure.Location
 }
 
+// Timeline() returns a timeline view of the report
+func (report SpecReport) Timeline() Timeline {
+	timeline := Timeline{}
+	if !report.Failure.IsZero() {
+		timeline = append(timeline, report.Failure)
+		if report.Failure.AdditionalFailure != nil {
+			timeline = append(timeline, *(report.Failure.AdditionalFailure))
+		}
+	}
+	for _, additionalFailure := range report.AdditionalFailures {
+		timeline = append(timeline, additionalFailure)
+	}
+	for _, reportEntry := range report.ReportEntries {
+		timeline = append(timeline, reportEntry)
+	}
+	for _, progressReport := range report.ProgressReports {
+		timeline = append(timeline, progressReport)
+	}
+	for _, specEvent := range report.SpecEvents {
+		timeline = append(timeline, specEvent)
+	}
+	sort.Sort(timeline)
+	return timeline
+}
+
 type SpecReports []SpecReport
 
-//WithLeafNodeType returns the subset of SpecReports with LeafNodeType matching one of the requested NodeTypes
+// WithLeafNodeType returns the subset of SpecReports with LeafNodeType matching one of the requested NodeTypes
 func (reports SpecReports) WithLeafNodeType(nodeTypes NodeType) SpecReports {
 	count := 0
 	for i := range reports {
@@ -344,7 +381,7 @@ func (reports SpecReports) WithLeafNodeType(nodeTypes NodeType) SpecReports {
 	return out
 }
 
-//WithState returns the subset of SpecReports with State matching one of the requested SpecStates
+// WithState returns the subset of SpecReports with State matching one of the requested SpecStates
 func (reports SpecReports) WithState(states SpecState) SpecReports {
 	count := 0
 	for i := range reports {
@@ -363,7 +400,7 @@ func (reports SpecReports) WithState(states SpecState) SpecReports {
 	return out
 }
 
-//CountWithState returns the number of SpecReports with State matching one of the requested SpecStates
+// CountWithState returns the number of SpecReports with State matching one of the requested SpecStates
 func (reports SpecReports) CountWithState(states SpecState) int {
 	n := 0
 	for i := range reports {
@@ -374,7 +411,7 @@ func (reports SpecReports) CountWithState(states SpecState) int {
 	return n
 }
 
-//If the Spec passes, CountOfFlakedSpecs returns the number of SpecReports that failed after multiple attempts.
+// If the Spec passes, CountOfFlakedSpecs returns the number of SpecReports that failed after multiple attempts.
 func (reports SpecReports) CountOfFlakedSpecs() int {
 	n := 0
 	for i := range reports {
@@ -385,7 +422,7 @@ func (reports SpecReports) CountOfFlakedSpecs() int {
 	return n
 }
 
-//If the Spec fails, CountOfRepeatedSpecs returns the number of SpecReports that passed after multiple attempts
+// If the Spec fails, CountOfRepeatedSpecs returns the number of SpecReports that passed after multiple attempts
 func (reports SpecReports) CountOfRepeatedSpecs() int {
 	n := 0
 	for i := range reports {
@@ -394,6 +431,53 @@ func (reports SpecReports) CountOfRepeatedSpecs() int {
 		}
 	}
 	return n
+}
+
+// TimelineLocation captures the location of an event in the spec's timeline
+type TimelineLocation struct {
+	//Offset is the offset (in bytes) of the event relative to the GinkgoWriter stream
+	Offset int `json:",omitempty"`
+
+	//Order is the order of the event with respect to other events.  The absolute value of Order
+	//is irrelevant.  All that matters is that an event with a lower Order occurs before ane vent with a higher Order
+	Order int `json:",omitempty"`
+
+	Time time.Time
+}
+
+// TimelineEvent represent an event on the timeline
+// consumers of Timeline will need to check the concrete type of each entry to determine how to handle it
+type TimelineEvent interface {
+	GetTimelineLocation() TimelineLocation
+}
+
+type Timeline []TimelineEvent
+
+func (t Timeline) Len() int { return len(t) }
+func (t Timeline) Less(i, j int) bool {
+	return t[i].GetTimelineLocation().Order < t[j].GetTimelineLocation().Order
+}
+func (t Timeline) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
+func (t Timeline) WithoutHiddenReportEntries() Timeline {
+	out := Timeline{}
+	for _, event := range t {
+		if reportEntry, isReportEntry := event.(ReportEntry); isReportEntry && reportEntry.Visibility == ReportEntryVisibilityNever {
+			continue
+		}
+		out = append(out, event)
+	}
+	return out
+}
+
+func (t Timeline) WithoutVeryVerboseSpecEvents() Timeline {
+	out := Timeline{}
+	for _, event := range t {
+		if specEvent, isSpecEvent := event.(SpecEvent); isSpecEvent && specEvent.IsOnlyVisibleAtVeryVerbose() {
+			continue
+		}
+		out = append(out, event)
+	}
+	return out
 }
 
 // Failure captures failure information for an individual test
@@ -408,6 +492,8 @@ type Failure struct {
 	// This CodeLocation will include a fully-populated StackTrace
 	Location CodeLocation
 
+	TimelineLocation TimelineLocation
+
 	// ForwardedPanic - if the failure represents a captured panic (i.e. Summary.State == SpecStatePanicked)
 	// then ForwardedPanic will be populated with a string representation of the captured panic.
 	ForwardedPanic string `json:",omitempty"`
@@ -420,17 +506,27 @@ type Failure struct {
 	// FailureNodeType will contain the NodeType of the node in which the failure occurred.
 	// FailureNodeLocation will contain the CodeLocation of the node in which the failure occurred.
 	// If populated, FailureNodeContainerIndex will be the index into SpecReport.ContainerHierarchyTexts and SpecReport.ContainerHierarchyLocations that represents the parent container of the node in which the failure occurred.
-	FailureNodeContext        FailureNodeContext
-	FailureNodeType           NodeType
-	FailureNodeLocation       CodeLocation
-	FailureNodeContainerIndex int
+	FailureNodeContext FailureNodeContext `json:",omitempty"`
+
+	FailureNodeType NodeType `json:",omitempty"`
+
+	FailureNodeLocation CodeLocation `json:",omitempty"`
+
+	FailureNodeContainerIndex int `json:",omitempty"`
 
 	//ProgressReport is populated if the spec was interrupted or timed out
-	ProgressReport ProgressReport
+	ProgressReport ProgressReport `json:",omitempty"`
+
+	//AdditionalFailure is non-nil if a follow-on failure occurred within the same node after the primary failure.  This only happens when a node has timed out or been interrupted.  In such cases the AdditionalFailure can include information about where/why the spec was stuck.
+	AdditionalFailure *AdditionalFailure `json:",omitempty"`
 }
 
 func (f Failure) IsZero() bool {
 	return f.Message == "" && (f.Location == CodeLocation{})
+}
+
+func (f Failure) GetTimelineLocation() TimelineLocation {
+	return f.TimelineLocation
 }
 
 // FailureNodeContext captures the location context for the node containing the failing line of code
@@ -469,6 +565,10 @@ func (fnc FailureNodeContext) MarshalJSON() ([]byte, error) {
 type AdditionalFailure struct {
 	State   SpecState
 	Failure Failure
+}
+
+func (f AdditionalFailure) GetTimelineLocation() TimelineLocation {
+	return f.Failure.TimelineLocation
 }
 
 // SpecState captures the state of a spec
@@ -520,36 +620,38 @@ func (ss SpecState) Is(states SpecState) bool {
 
 // ProgressReport captures the progress of the current spec.  It is, effectively, a structured Ginkgo-aware stack trace
 type ProgressReport struct {
-	Message           string
-	ParallelProcess   int
-	RunningInParallel bool
+	Message           string `json:",omitempty"`
+	ParallelProcess   int    `json:",omitempty"`
+	RunningInParallel bool   `json:",omitempty"`
 
-	Time time.Time
+	ContainerHierarchyTexts []string     `json:",omitempty"`
+	LeafNodeText            string       `json:",omitempty"`
+	LeafNodeLocation        CodeLocation `json:",omitempty"`
+	SpecStartTime           time.Time    `json:",omitempty"`
 
-	ContainerHierarchyTexts []string
-	LeafNodeText            string
-	LeafNodeLocation        CodeLocation
-	SpecStartTime           time.Time
+	CurrentNodeType      NodeType     `json:",omitempty"`
+	CurrentNodeText      string       `json:",omitempty"`
+	CurrentNodeLocation  CodeLocation `json:",omitempty"`
+	CurrentNodeStartTime time.Time    `json:",omitempty"`
 
-	CurrentNodeType      NodeType
-	CurrentNodeText      string
-	CurrentNodeLocation  CodeLocation
-	CurrentNodeStartTime time.Time
+	CurrentStepText      string       `json:",omitempty"`
+	CurrentStepLocation  CodeLocation `json:",omitempty"`
+	CurrentStepStartTime time.Time    `json:",omitempty"`
 
-	CurrentStepText      string
-	CurrentStepLocation  CodeLocation
-	CurrentStepStartTime time.Time
+	AdditionalReports []string `json:",omitempty"`
 
-	AdditionalReports []string
+	CapturedGinkgoWriterOutput string           `json:",omitempty"`
+	TimelineLocation           TimelineLocation `json:",omitempty"`
 
-	CapturedGinkgoWriterOutput string `json:",omitempty"`
-	GinkgoWriterOffset         int
-
-	Goroutines []Goroutine
+	Goroutines []Goroutine `json:",omitempty"`
 }
 
 func (pr ProgressReport) IsZero() bool {
 	return pr.CurrentNodeType == NodeTypeInvalid
+}
+
+func (pr ProgressReport) Time() time.Time {
+	return pr.TimelineLocation.Time
 }
 
 func (pr ProgressReport) SpecGoroutine() Goroutine {
@@ -587,6 +689,22 @@ func (pr ProgressReport) WithoutCapturedGinkgoWriterOutput() ProgressReport {
 	out := pr
 	out.CapturedGinkgoWriterOutput = ""
 	return out
+}
+
+func (pr ProgressReport) WithoutOtherGoroutines() ProgressReport {
+	out := pr
+	filteredGoroutines := []Goroutine{}
+	for _, goroutine := range pr.Goroutines {
+		if goroutine.IsSpecGoroutine || goroutine.HasHighlights() {
+			filteredGoroutines = append(filteredGoroutines, goroutine)
+		}
+	}
+	out.Goroutines = filteredGoroutines
+	return out
+}
+
+func (pr ProgressReport) GetTimelineLocation() TimelineLocation {
+	return pr.TimelineLocation
 }
 
 type Goroutine struct {
@@ -693,4 +811,100 @@ func (nt NodeType) MarshalJSON() ([]byte, error) {
 
 func (nt NodeType) Is(nodeTypes NodeType) bool {
 	return nt&nodeTypes != 0
+}
+
+/*
+SpecEvent captures a vareity of events that can occur when specs run.  See SpecEventType for the list of available events.
+*/
+type SpecEvent struct {
+	SpecEventType SpecEventType
+
+	CodeLocation     CodeLocation
+	TimelineLocation TimelineLocation
+
+	Message  string        `json:",omitempty"`
+	Duration time.Duration `json:",omitempty"`
+	NodeType NodeType      `json:",omitempty"`
+	Attempt  int           `json:",omitempty"`
+}
+
+func (se SpecEvent) GetTimelineLocation() TimelineLocation {
+	return se.TimelineLocation
+}
+
+func (se SpecEvent) IsOnlyVisibleAtVeryVerbose() bool {
+	return se.SpecEventType.Is(SpecEventByEnd | SpecEventNodeStart | SpecEventNodeEnd)
+}
+
+func (se SpecEvent) GomegaString() string {
+	out := &strings.Builder{}
+	out.WriteString("[" + se.SpecEventType.String() + " SpecEvent] ")
+	if se.Message != "" {
+		out.WriteString("Message=")
+		out.WriteString(`"` + se.Message + `",`)
+	}
+	if se.Duration != 0 {
+		out.WriteString("Duration=" + se.Duration.String() + ",")
+	}
+	if se.NodeType != NodeTypeInvalid {
+		out.WriteString("NodeType=" + se.NodeType.String() + ",")
+	}
+	if se.Attempt != 0 {
+		out.WriteString(fmt.Sprintf("Attempt=%d", se.Attempt) + ",")
+	}
+	out.WriteString("CL=" + se.CodeLocation.String() + ",")
+	out.WriteString(fmt.Sprintf("TL.Offset=%d", se.TimelineLocation.Offset))
+
+	return out.String()
+}
+
+type SpecEvents []SpecEvent
+
+func (se SpecEvents) WithType(seType SpecEventType) SpecEvents {
+	out := SpecEvents{}
+	for _, event := range se {
+		if event.SpecEventType.Is(seType) {
+			out = append(out, event)
+		}
+	}
+	return out
+}
+
+type SpecEventType uint
+
+const (
+	SpecEventInvalid SpecEventType = 0
+
+	SpecEventByStart SpecEventType = 1 << iota
+	SpecEventByEnd
+	SpecEventNodeStart
+	SpecEventNodeEnd
+	SpecEventSpecRepeat
+	SpecEventSpecRetry
+)
+
+var seEnumSupport = NewEnumSupport(map[uint]string{
+	uint(SpecEventInvalid):    "INVALID SPEC EVENT",
+	uint(SpecEventByStart):    "By",
+	uint(SpecEventByEnd):      "By (End)",
+	uint(SpecEventNodeStart):  "Node",
+	uint(SpecEventNodeEnd):    "Node (End)",
+	uint(SpecEventSpecRepeat): "Repeat",
+	uint(SpecEventSpecRetry):  "Retry",
+})
+
+func (se SpecEventType) String() string {
+	return seEnumSupport.String(uint(se))
+}
+func (se *SpecEventType) UnmarshalJSON(b []byte) error {
+	out, err := seEnumSupport.UnmarshJSON(b)
+	*se = SpecEventType(out)
+	return err
+}
+func (se SpecEventType) MarshalJSON() ([]byte, error) {
+	return seEnumSupport.MarshJSON(uint(se))
+}
+
+func (se SpecEventType) Is(specEventTypes SpecEventType) bool {
+	return se&specEventTypes != 0
 }

--- a/vendor/github.com/onsi/ginkgo/v2/types/version.go
+++ b/vendor/github.com/onsi/ginkgo/v2/types/version.go
@@ -1,3 +1,3 @@
 package types
 
-const VERSION = "2.4.0"
+const VERSION = "2.5.0"

--- a/vendor/github.com/onsi/gomega/.gitignore
+++ b/vendor/github.com/onsi/gomega/.gitignore
@@ -3,3 +3,4 @@
 .
 .idea
 gomega.iml
+TODO.md

--- a/vendor/github.com/onsi/gomega/CHANGELOG.md
+++ b/vendor/github.com/onsi/gomega/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 1.24.0
+
+### Features
+
+Introducting [gcustom](https://onsi.github.io/gomega/#gcustom-a-convenient-mechanism-for-buildling-custom-matchers) - a convenient mechanism for building custom matchers.
+
+This is an RC release for `gcustom`.  The external API may be tweaked in response to feedback however it is expected to remain mostly stable.
+
+### Maintenance
+
+- Update BeComparableTo documentation [756eaa0]
+
+## 1.23.0
+
+### Features
+- Custom formatting on a per-type basis can be provided using `format.RegisterCustomFormatter()` -- see the docs [here](https://onsi.github.io/gomega/#adjusting-output)
+
+- Substantial improvement have been made to `StopTrying()`:
+  - Users can now use `StopTrying().Wrap(err)` to wrap errors and `StopTrying().Attach(description, object)` to attach arbitrary objects to the `StopTrying()` error
+  - `StopTrying()` is now always interpreted as a failure.  If you are an early adopter of `StopTrying()` you may need to change your code as the prior version would match against the returned value even if `StopTrying()` was returned.  Going forward the `StopTrying()` api should remain stable.
+  - `StopTrying()` and `StopTrying().Now()` can both be used in matchers - not just polled functions.
+
+- `TryAgainAfter(duration)` is used like `StopTrying()` but instructs `Eventually` and `Consistently` that the poll should be tried again after the specified duration.  This allows you to dynamically adjust the polling duration.
+
+- `ctx` can now be passed-in as the first argument to `Eventually` and `Consistently`.
+
+## Maintenance
+
+- Bump github.com/onsi/ginkgo/v2 from 2.3.0 to 2.3.1 (#597) [afed901]
+- Bump nokogiri from 1.13.8 to 1.13.9 in /docs (#599) [7c691b3]
+- Bump github.com/google/go-cmp from 0.5.8 to 0.5.9 (#587) [ff22665]
+
 ## 1.22.1
 
 ## Fixes

--- a/vendor/github.com/onsi/gomega/RELEASING.md
+++ b/vendor/github.com/onsi/gomega/RELEASING.md
@@ -5,7 +5,7 @@ A Gomega release is a tagged sha and a GitHub release.  To cut a release:
     ```bash
     LAST_VERSION=$(git tag --sort=version:refname | tail -n1)
     CHANGES=$(git log --pretty=format:'- %s [%h]' HEAD...$LAST_VERSION)
-    echo -e "## NEXT\n\n$CHANGES\n\n### Features\n\n## Fixes\n\n## Maintenance\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
+    echo -e "## NEXT\n\n$CHANGES\n\n### Features\n\n### Fixes\n\n### Maintenance\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
     ```
    to update the changelog
   - Categorize the changes into

--- a/vendor/github.com/onsi/gomega/format/format.go
+++ b/vendor/github.com/onsi/gomega/format/format.go
@@ -66,6 +66,52 @@ type GomegaStringer interface {
 }
 
 /*
+CustomFormatters can be registered with Gomega via RegisterCustomFormatter()
+Any value to be rendered by Gomega is passed to each registered CustomFormatters.
+The CustomFormatter signals that it will handle formatting the value by returning (formatted-string, true)
+If the CustomFormatter does not want to handle the object it should return ("", false)
+
+Strings returned by CustomFormatters are not truncated
+*/
+type CustomFormatter func(value interface{}) (string, bool)
+type CustomFormatterKey uint
+
+var customFormatterKey CustomFormatterKey = 1
+
+type customFormatterKeyPair struct {
+	CustomFormatter
+	CustomFormatterKey
+}
+
+/*
+RegisterCustomFormatter registers a CustomFormatter and returns a CustomFormatterKey
+
+You can call UnregisterCustomFormatter with the returned key to unregister the associated CustomFormatter
+*/
+func RegisterCustomFormatter(customFormatter CustomFormatter) CustomFormatterKey {
+	key := customFormatterKey
+	customFormatterKey += 1
+	customFormatters = append(customFormatters, customFormatterKeyPair{customFormatter, key})
+	return key
+}
+
+/*
+UnregisterCustomFormatter unregisters a previously registered CustomFormatter.  You should pass in the key returned by RegisterCustomFormatter
+*/
+func UnregisterCustomFormatter(key CustomFormatterKey) {
+	formatters := []customFormatterKeyPair{}
+	for _, f := range customFormatters {
+		if f.CustomFormatterKey == key {
+			continue
+		}
+		formatters = append(formatters, f)
+	}
+	customFormatters = formatters
+}
+
+var customFormatters = []customFormatterKeyPair{}
+
+/*
 Generates a formatted matcher success/failure message of the form:
 
 	Expected
@@ -219,17 +265,24 @@ func Object(object interface{}, indentation uint) string {
 IndentString takes a string and indents each line by the specified amount.
 */
 func IndentString(s string, indentation uint) string {
+	return indentString(s, indentation, true)
+}
+
+func indentString(s string, indentation uint, indentFirstLine bool) string {
+	result := &strings.Builder{}
 	components := strings.Split(s, "\n")
-	result := ""
 	indent := strings.Repeat(Indent, int(indentation))
 	for i, component := range components {
-		result += indent + component
+		if i > 0 || indentFirstLine {
+			result.WriteString(indent)
+		}
+		result.WriteString(component)
 		if i < len(components)-1 {
-			result += "\n"
+			result.WriteString("\n")
 		}
 	}
 
-	return result
+	return result.String()
 }
 
 func formatType(v reflect.Value) string {
@@ -261,18 +314,27 @@ func formatValue(value reflect.Value, indentation uint) string {
 	if value.CanInterface() {
 		obj := value.Interface()
 
+		// if a CustomFormatter handles this values, we'll go with that
+		for _, customFormatter := range customFormatters {
+			formatted, handled := customFormatter.CustomFormatter(obj)
+			// do not truncate a user-provided CustomFormatter()
+			if handled {
+				return indentString(formatted, indentation+1, false)
+			}
+		}
+
 		// GomegaStringer will take precedence to other representations and disregards UseStringerRepresentation
 		if x, ok := obj.(GomegaStringer); ok {
-			// do not truncate a user-defined GoMegaString() value
-			return x.GomegaString()
+			// do not truncate a user-defined GomegaString() value
+			return indentString(x.GomegaString(), indentation+1, false)
 		}
 
 		if UseStringerRepresentation {
 			switch x := obj.(type) {
 			case fmt.GoStringer:
-				return truncateLongStrings(x.GoString())
+				return indentString(truncateLongStrings(x.GoString()), indentation+1, false)
 			case fmt.Stringer:
-				return truncateLongStrings(x.String())
+				return indentString(truncateLongStrings(x.String()), indentation+1, false)
 			}
 		}
 	}

--- a/vendor/github.com/onsi/gomega/gomega_dsl.go
+++ b/vendor/github.com/onsi/gomega/gomega_dsl.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onsi/gomega/types"
 )
 
-const GOMEGA_VERSION = "1.22.1"
+const GOMEGA_VERSION = "1.24.0"
 
 const nilGomegaPanic = `You are trying to make an assertion, but haven't registered Gomega's fail handler.
 If you're using Ginkgo then you probably forgot to put your assertion in an It().
@@ -86,12 +86,12 @@ func internalGomega(g Gomega) *internal.Gomega {
 // NewWithT takes a *testing.T and returns a `gomega.WithT` allowing you to use `Expect`, `Eventually`, and `Consistently` along with
 // Gomega's rich ecosystem of matchers in standard `testing` test suits.
 //
-//    func TestFarmHasCow(t *testing.T) {
-//        g := gomega.NewWithT(t)
+//	func TestFarmHasCow(t *testing.T) {
+//	    g := gomega.NewWithT(t)
 //
-//        f := farm.New([]string{"Cow", "Horse"})
-//        g.Expect(f.HasCow()).To(BeTrue(), "Farm should have cow")
-//     }
+//	    f := farm.New([]string{"Cow", "Horse"})
+//	    g.Expect(f.HasCow()).To(BeTrue(), "Farm should have cow")
+//	 }
 func NewWithT(t types.GomegaTestingT) *WithT {
 	return internal.NewGomega(internalGomega(Default).DurationBundle).ConfigureWithT(t)
 }
@@ -171,7 +171,8 @@ func ensureDefaultGomegaIsConfigured() {
 }
 
 // Ω wraps an actual value allowing assertions to be made on it:
-//    Ω("foo").Should(Equal("foo"))
+//
+//	Ω("foo").Should(Equal("foo"))
 //
 // If Ω is passed more than one argument it will pass the *first* argument to the matcher.
 // All subsequent arguments will be required to be nil/zero.
@@ -180,10 +181,13 @@ func ensureDefaultGomegaIsConfigured() {
 // a value and an error - a common patter in Go.
 //
 // For example, given a function with signature:
-//    func MyAmazingThing() (int, error)
+//
+//	func MyAmazingThing() (int, error)
 //
 // Then:
-//    Ω(MyAmazingThing()).Should(Equal(3))
+//
+//	Ω(MyAmazingThing()).Should(Equal(3))
+//
 // Will succeed only if `MyAmazingThing()` returns `(3, nil)`
 //
 // Ω and Expect are identical
@@ -193,7 +197,8 @@ func Ω(actual interface{}, extra ...interface{}) Assertion {
 }
 
 // Expect wraps an actual value allowing assertions to be made on it:
-//    Expect("foo").To(Equal("foo"))
+//
+//	Expect("foo").To(Equal("foo"))
 //
 // If Expect is passed more than one argument it will pass the *first* argument to the matcher.
 // All subsequent arguments will be required to be nil/zero.
@@ -202,10 +207,13 @@ func Ω(actual interface{}, extra ...interface{}) Assertion {
 // a value and an error - a common patter in Go.
 //
 // For example, given a function with signature:
-//    func MyAmazingThing() (int, error)
+//
+//	func MyAmazingThing() (int, error)
 //
 // Then:
-//    Expect(MyAmazingThing()).Should(Equal(3))
+//
+//	Expect(MyAmazingThing()).Should(Equal(3))
+//
 // Will succeed only if `MyAmazingThing()` returns `(3, nil)`
 //
 // Expect and Ω are identical
@@ -215,7 +223,8 @@ func Expect(actual interface{}, extra ...interface{}) Assertion {
 }
 
 // ExpectWithOffset wraps an actual value allowing assertions to be made on it:
-//    ExpectWithOffset(1, "foo").To(Equal("foo"))
+//
+//	ExpectWithOffset(1, "foo").To(Equal("foo"))
 //
 // Unlike `Expect` and `Ω`, `ExpectWithOffset` takes an additional integer argument
 // that is used to modify the call-stack offset when computing line numbers. It is
@@ -241,15 +250,15 @@ Eventually works with any Gomega compatible matcher and supports making assertio
 
 There are several examples of values that can change over time.  These can be passed in to Eventually and will be passed to the matcher repeatedly until a match occurs.  For example:
 
-    c := make(chan bool)
-    go DoStuff(c)
-    Eventually(c, "50ms").Should(BeClosed())
+	c := make(chan bool)
+	go DoStuff(c)
+	Eventually(c, "50ms").Should(BeClosed())
 
 will poll the channel repeatedly until it is closed.  In this example `Eventually` will block until either the specified timeout of 50ms has elapsed or the channel is closed, whichever comes first.
 
 Several Gomega libraries allow you to use Eventually in this way.  For example, the gomega/gexec package allows you to block until a *gexec.Session exits successfully via:
 
-    Eventually(session).Should(gexec.Exit(0))
+	Eventually(session).Should(gexec.Exit(0))
 
 And the gomega/gbytes package allows you to monitor a streaming *gbytes.Buffer until a given string is seen:
 
@@ -270,34 +279,38 @@ Eventually can be passed functions that **return at least one value**.  When con
 
 For example:
 
-    Eventually(func() int {
-    	return client.FetchCount()
-    }).Should(BeNumerically(">=", 17))
+	   Eventually(func() int {
+	   	return client.FetchCount()
+	   }).Should(BeNumerically(">=", 17))
 
- will repeatedly poll client.FetchCount until the BeNumerically matcher is satisfied.  (Note that this example could have been written as Eventually(client.FetchCount).Should(BeNumerically(">=", 17)))
+	will repeatedly poll client.FetchCount until the BeNumerically matcher is satisfied.  (Note that this example could have been written as Eventually(client.FetchCount).Should(BeNumerically(">=", 17)))
 
 If multiple values are returned by the function, Eventually will pass the first value to the matcher and require that all others are zero-valued.  This allows you to pass Eventually a function that returns a value and an error - a common pattern in Go.
 
 For example, consider a method that returns a value and an error:
-    func FetchFromDB() (string, error)
+
+	func FetchFromDB() (string, error)
 
 Then
-    Eventually(FetchFromDB).Should(Equal("got it"))
+
+	Eventually(FetchFromDB).Should(Equal("got it"))
 
 will pass only if and when the returned error is nil *and* the returned string satisfies the matcher.
 
 Eventually can also accept functions that take arguments, however you must provide those arguments using .WithArguments().  For example, consider a function that takes a user-id and makes a network request to fetch a full name:
+
 	func FetchFullName(userId int) (string, error)
 
 You can poll this function like so:
+
 	Eventually(FetchFullName).WithArguments(1138).Should(Equal("Wookie"))
 
 It is important to note that the function passed into Eventually is invoked *synchronously* when polled.  Eventually does not (in fact, it cannot) kill the function if it takes longer to return than Eventually's configured timeout.  A common practice here is to use a context.  Here's an example that combines Ginkgo's spec timeout support with Eventually:
 
 	It("fetches the correct count", func(ctx SpecContext) {
-		Eventually(func() int {
+		Eventually(ctx, func() int {
 			return client.FetchCount(ctx, "/users")
-		}, ctx).Should(BeNumerically(">=", 17))
+		}).Should(BeNumerically(">=", 17))
 	}, SpecTimeout(time.Second))
 
 you an also use Eventually().WithContext(ctx) to pass in the context.  Passed-in contexts play nicely with paseed-in arguments as long as the context appears first.  You can rewrite the above example as:
@@ -326,13 +339,13 @@ will pass only if all the assertions in the polled function pass and the return 
 Eventually also supports a special case polling function that takes a single Gomega argument and returns no values.  Eventually assumes such a function is making assertions and is designed to work with the Succeed matcher to validate that all assertions have passed.
 For example:
 
-    Eventually(func(g Gomega) {
-    	model, err := client.Find(1138)
-    	g.Expect(err).NotTo(HaveOccurred())
-    	g.Expect(model.Reticulate()).To(Succeed())
-    	g.Expect(model.IsReticulated()).To(BeTrue())
-    	g.Expect(model.Save()).To(Succeed())
-    }).Should(Succeed())
+	Eventually(func(g Gomega) {
+		model, err := client.Find(1138)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(model.Reticulate()).To(Succeed())
+		g.Expect(model.IsReticulated()).To(BeTrue())
+		g.Expect(model.Save()).To(Succeed())
+	}).Should(Succeed())
 
 will rerun the function until all assertions pass.
 
@@ -353,11 +366,11 @@ Finally, in addition to passing timeouts and a context to Eventually you can be 
 
 is equivalent to
 
-    Eventually(...).WithTimeout(time.Second).WithPolling(2*time.Second).WithContext(ctx).Should(...)
+	Eventually(...).WithTimeout(time.Second).WithPolling(2*time.Second).WithContext(ctx).Should(...)
 */
-func Eventually(actual interface{}, args ...interface{}) AsyncAssertion {
+func Eventually(args ...interface{}) AsyncAssertion {
 	ensureDefaultGomegaIsConfigured()
-	return Default.Eventually(actual, args...)
+	return Default.Eventually(args...)
 }
 
 // EventuallyWithOffset operates like Eventually but takes an additional
@@ -369,9 +382,9 @@ func Eventually(actual interface{}, args ...interface{}) AsyncAssertion {
 // `EventuallyWithOffset` specifying a timeout interval (and an optional polling interval) are
 // the same as `Eventually(...).WithOffset(...).WithTimeout` or
 // `Eventually(...).WithOffset(...).WithTimeout(...).WithPolling`.
-func EventuallyWithOffset(offset int, actual interface{}, args ...interface{}) AsyncAssertion {
+func EventuallyWithOffset(offset int, args ...interface{}) AsyncAssertion {
 	ensureDefaultGomegaIsConfigured()
-	return Default.EventuallyWithOffset(offset, actual, args...)
+	return Default.EventuallyWithOffset(offset, args...)
 }
 
 /*
@@ -385,13 +398,13 @@ Consistently accepts the same three categories of actual as Eventually, check th
 
 Consistently is useful in cases where you want to assert that something *does not happen* for a period of time.  For example, you may want to assert that a goroutine does *not* send data down a channel.  In this case you could write:
 
-    Consistently(channel, "200ms").ShouldNot(Receive())
+	Consistently(channel, "200ms").ShouldNot(Receive())
 
 This will block for 200 milliseconds and repeatedly check the channel and ensure nothing has been received.
 */
-func Consistently(actual interface{}, args ...interface{}) AsyncAssertion {
+func Consistently(args ...interface{}) AsyncAssertion {
 	ensureDefaultGomegaIsConfigured()
-	return Default.Consistently(actual, args...)
+	return Default.Consistently(args...)
 }
 
 // ConsistentlyWithOffset operates like Consistently but takes an additional
@@ -400,43 +413,53 @@ func Consistently(actual interface{}, args ...interface{}) AsyncAssertion {
 //
 // `ConsistentlyWithOffset` is the same as `Consistently(...).WithOffset` and
 // optional `WithTimeout` and `WithPolling`.
-func ConsistentlyWithOffset(offset int, actual interface{}, args ...interface{}) AsyncAssertion {
+func ConsistentlyWithOffset(offset int, args ...interface{}) AsyncAssertion {
 	ensureDefaultGomegaIsConfigured()
-	return Default.ConsistentlyWithOffset(offset, actual, args...)
+	return Default.ConsistentlyWithOffset(offset, args...)
 }
 
 /*
-StopTrying can be used to signal to Eventually and Consistently that the polled function will not change
-and that they should stop trying.  In the case of Eventually, if a match does not occur in this, final, iteration then a failure will result.  In the case of Consistently, as long as this last iteration satisfies the match, the assertion will be considered successful.
+StopTrying can be used to signal to Eventually and Consistentlythat they should abort and stop trying.  This always results in a failure of the assertion - and the failure message is the content of the StopTrying signal.
 
-You can send the StopTrying signal by either returning a StopTrying("message") messages as an error from your passed-in function  _or_ by calling StopTrying("message").Now() to trigger a panic and end execution.
+You can send the StopTrying signal by either returning StopTrying("message") as an error from your passed-in function _or_ by calling StopTrying("message").Now() to trigger a panic and end execution.
+
+You can also wrap StopTrying around an error with `StopTrying("message").Wrap(err)` and can attach additional objects via `StopTrying("message").Attach("description", object).  When rendered, the signal will include the wrapped error and any attached objects rendered using Gomega's default formatting.
 
 Here are a couple of examples.  This is how you might use StopTrying() as an error to signal that Eventually should stop:
 
 	playerIndex, numPlayers := 0, 11
 	Eventually(func() (string, error) {
-		name := client.FetchPlayer(playerIndex)
-		playerIndex += 1
-		if playerIndex == numPlayers {
-			return name, StopTrying("No more players left")
-		} else {
-			return name, nil
-		}
+	    if playerIndex == numPlayers {
+	        return "", StopTrying("no more players left")
+	    }
+	    name := client.FetchPlayer(playerIndex)
+	    playerIndex += 1
+	    return name, nil
 	}).Should(Equal("Patrick Mahomes"))
-
-note that the final `name` returned alongside `StopTrying()` will be processed.
 
 And here's an example where `StopTrying().Now()` is called to halt execution immediately:
 
 	Eventually(func() []string {
 		names, err := client.FetchAllPlayers()
 		if err == client.IRRECOVERABLE_ERROR {
-			StopTrying("Irrecoverable error occurred").Now()
+			StopTrying("Irrecoverable error occurred").Wrap(err).Now()
 		}
 		return names
 	}).Should(ContainElement("Patrick Mahomes"))
 */
 var StopTrying = internal.StopTrying
+
+/*
+TryAgainAfter(<duration>) allows you to adjust the polling interval for the _next_ iteration of `Eventually` or `Consistently`.  Like `StopTrying` you can either return `TryAgainAfter` as an error or trigger it immedieately with `.Now()`
+
+When `TryAgainAfter(<duration>` is triggered `Eventually` and `Consistently` will wait for that duration.  If a timeout occurs before the next poll is triggered both `Eventually` and `Consistently` will always fail with the content of the TryAgainAfter message.  As with StopTrying you can `.Wrap()` and error and `.Attach()` additional objects to `TryAgainAfter`.
+*/
+var TryAgainAfter = internal.TryAgainAfter
+
+/*
+PollingSignalError is the error returned by StopTrying() and TryAgainAfter()
+*/
+type PollingSignalError = internal.PollingSignalError
 
 // SetDefaultEventuallyTimeout sets the default timeout duration for Eventually. Eventually will repeatedly poll your condition until it succeeds, or until this timeout elapses.
 func SetDefaultEventuallyTimeout(t time.Duration) {
@@ -471,8 +494,8 @@ func SetDefaultConsistentlyPollingInterval(t time.Duration) {
 //
 // Example:
 //
-//   Eventually(myChannel).Should(Receive(), "Something should have come down the pipe.")
-//   Consistently(myChannel).ShouldNot(Receive(), func() string { return "Nothing should have come down the pipe." })
+//	Eventually(myChannel).Should(Receive(), "Something should have come down the pipe.")
+//	Consistently(myChannel).ShouldNot(Receive(), func() string { return "Nothing should have come down the pipe." })
 type AsyncAssertion = types.AsyncAssertion
 
 // GomegaAsyncAssertion is deprecated in favor of AsyncAssertion, which does not stutter.
@@ -494,7 +517,7 @@ type GomegaAsyncAssertion = types.AsyncAssertion
 //
 // Example:
 //
-//    Ω(farm.HasCow()).Should(BeTrue(), "Farm %v should have a cow", farm)
+//	Ω(farm.HasCow()).Should(BeTrue(), "Farm %v should have a cow", farm)
 type Assertion = types.Assertion
 
 // GomegaAssertion is deprecated in favor of Assertion, which does not stutter.

--- a/vendor/github.com/onsi/gomega/internal/assertion.go
+++ b/vendor/github.com/onsi/gomega/internal/assertion.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
 )
 
@@ -146,7 +147,12 @@ func vetActuals(actuals []interface{}, skipIndex int) (bool, string) {
 		if actual != nil {
 			zeroValue := reflect.Zero(reflect.TypeOf(actual)).Interface()
 			if !reflect.DeepEqual(zeroValue, actual) {
-				message := fmt.Sprintf("Unexpected non-nil/non-zero argument at index %d:\n\t<%T>: %#v", i, actual, actual)
+				var message string
+				if err, ok := actual.(error); ok {
+					message = fmt.Sprintf("Unexpected error: %s\n%s", err, format.Object(err, 1))
+				} else {
+					message = fmt.Sprintf("Unexpected non-nil/non-zero argument at index %d:\n\t<%T>: %#v", i, actual, actual)
+				}
 				return false, message
 			}
 		}

--- a/vendor/github.com/onsi/gomega/internal/duration_bundle.go
+++ b/vendor/github.com/onsi/gomega/internal/duration_bundle.go
@@ -44,28 +44,28 @@ func durationFromEnv(key string, defaultDuration time.Duration) time.Duration {
 	return duration
 }
 
-func toDuration(input interface{}) time.Duration {
+func toDuration(input interface{}) (time.Duration, error) {
 	duration, ok := input.(time.Duration)
 	if ok {
-		return duration
+		return duration, nil
 	}
 
 	value := reflect.ValueOf(input)
 	kind := reflect.TypeOf(input).Kind()
 
 	if reflect.Int <= kind && kind <= reflect.Int64 {
-		return time.Duration(value.Int()) * time.Second
+		return time.Duration(value.Int()) * time.Second, nil
 	} else if reflect.Uint <= kind && kind <= reflect.Uint64 {
-		return time.Duration(value.Uint()) * time.Second
+		return time.Duration(value.Uint()) * time.Second, nil
 	} else if reflect.Float32 <= kind && kind <= reflect.Float64 {
-		return time.Duration(value.Float() * float64(time.Second))
+		return time.Duration(value.Float() * float64(time.Second)), nil
 	} else if reflect.String == kind {
 		duration, err := time.ParseDuration(value.String())
 		if err != nil {
-			panic(fmt.Sprintf("%#v is not a valid parsable duration string.", input))
+			return 0, fmt.Errorf("%#v is not a valid parsable duration string: %w", input, err)
 		}
-		return duration
+		return duration, nil
 	}
 
-	panic(fmt.Sprintf("%v is not a valid interval.  Must be time.Duration, parsable duration string or a number.", input))
+	return 0, fmt.Errorf("%#v is not a valid interval. Must be a time.Duration, a parsable duration string, or a number.", input)
 }

--- a/vendor/github.com/onsi/gomega/internal/gomega.go
+++ b/vendor/github.com/onsi/gomega/internal/gomega.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/onsi/gomega/types"
@@ -52,16 +53,46 @@ func (g *Gomega) ExpectWithOffset(offset int, actual interface{}, extra ...inter
 	return NewAssertion(actual, g, offset, extra...)
 }
 
-func (g *Gomega) Eventually(actual interface{}, intervals ...interface{}) types.AsyncAssertion {
-	return g.EventuallyWithOffset(0, actual, intervals...)
+func (g *Gomega) Eventually(args ...interface{}) types.AsyncAssertion {
+	return g.makeAsyncAssertion(AsyncAssertionTypeEventually, 0, args...)
 }
 
-func (g *Gomega) EventuallyWithOffset(offset int, actual interface{}, args ...interface{}) types.AsyncAssertion {
+func (g *Gomega) EventuallyWithOffset(offset int, args ...interface{}) types.AsyncAssertion {
+	return g.makeAsyncAssertion(AsyncAssertionTypeEventually, offset, args...)
+}
+
+func (g *Gomega) Consistently(args ...interface{}) types.AsyncAssertion {
+	return g.makeAsyncAssertion(AsyncAssertionTypeConsistently, 0, args...)
+}
+
+func (g *Gomega) ConsistentlyWithOffset(offset int, args ...interface{}) types.AsyncAssertion {
+	return g.makeAsyncAssertion(AsyncAssertionTypeConsistently, offset, args...)
+}
+
+func (g *Gomega) makeAsyncAssertion(asyncAssertionType AsyncAssertionType, offset int, args ...interface{}) types.AsyncAssertion {
+	baseOffset := 3
 	timeoutInterval := -time.Duration(1)
 	pollingInterval := -time.Duration(1)
 	intervals := []interface{}{}
 	var ctx context.Context
-	for _, arg := range args {
+	if len(args) == 0 {
+		g.Fail(fmt.Sprintf("Call to %s is missing a value or function to poll", asyncAssertionType), offset+baseOffset)
+		return nil
+	}
+
+	actual := args[0]
+	startingIndex := 1
+	if _, isCtx := args[0].(context.Context); isCtx && len(args) > 1 {
+		// the first argument is a context, we should accept it as the context _only if_ it is **not** the only argumnent **and** the second argument is not a parseable duration
+		// this is due to an unfortunate ambiguity in early version of Gomega in which multi-type durations are allowed after the actual
+		if _, err := toDuration(args[1]); err != nil {
+			ctx = args[0].(context.Context)
+			actual = args[1]
+			startingIndex = 2
+		}
+	}
+
+	for _, arg := range args[startingIndex:] {
 		switch v := arg.(type) {
 		case context.Context:
 			ctx = v
@@ -69,41 +100,21 @@ func (g *Gomega) EventuallyWithOffset(offset int, actual interface{}, args ...in
 			intervals = append(intervals, arg)
 		}
 	}
+	var err error
 	if len(intervals) > 0 {
-		timeoutInterval = toDuration(intervals[0])
-	}
-	if len(intervals) > 1 {
-		pollingInterval = toDuration(intervals[1])
-	}
-
-	return NewAsyncAssertion(AsyncAssertionTypeEventually, actual, g, timeoutInterval, pollingInterval, ctx, offset)
-}
-
-func (g *Gomega) Consistently(actual interface{}, intervals ...interface{}) types.AsyncAssertion {
-	return g.ConsistentlyWithOffset(0, actual, intervals...)
-}
-
-func (g *Gomega) ConsistentlyWithOffset(offset int, actual interface{}, args ...interface{}) types.AsyncAssertion {
-	timeoutInterval := -time.Duration(1)
-	pollingInterval := -time.Duration(1)
-	intervals := []interface{}{}
-	var ctx context.Context
-	for _, arg := range args {
-		switch v := arg.(type) {
-		case context.Context:
-			ctx = v
-		default:
-			intervals = append(intervals, arg)
+		timeoutInterval, err = toDuration(intervals[0])
+		if err != nil {
+			g.Fail(err.Error(), offset+baseOffset)
 		}
 	}
-	if len(intervals) > 0 {
-		timeoutInterval = toDuration(intervals[0])
-	}
 	if len(intervals) > 1 {
-		pollingInterval = toDuration(intervals[1])
+		pollingInterval, err = toDuration(intervals[1])
+		if err != nil {
+			g.Fail(err.Error(), offset+baseOffset)
+		}
 	}
 
-	return NewAsyncAssertion(AsyncAssertionTypeConsistently, actual, g, timeoutInterval, pollingInterval, ctx, offset)
+	return NewAsyncAssertion(asyncAssertionType, actual, g, timeoutInterval, pollingInterval, ctx, offset)
 }
 
 func (g *Gomega) SetDefaultEventuallyTimeout(t time.Duration) {

--- a/vendor/github.com/onsi/gomega/internal/polling_signal_error.go
+++ b/vendor/github.com/onsi/gomega/internal/polling_signal_error.go
@@ -1,0 +1,106 @@
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+type PollingSignalErrorType int
+
+const (
+	PollingSignalErrorTypeStopTrying PollingSignalErrorType = iota
+	PollingSignalErrorTypeTryAgainAfter
+)
+
+type PollingSignalError interface {
+	error
+	Wrap(err error) PollingSignalError
+	Attach(description string, obj any) PollingSignalError
+	Now()
+}
+
+var StopTrying = func(message string) PollingSignalError {
+	return &PollingSignalErrorImpl{
+		message:                message,
+		pollingSignalErrorType: PollingSignalErrorTypeStopTrying,
+	}
+}
+
+var TryAgainAfter = func(duration time.Duration) PollingSignalError {
+	return &PollingSignalErrorImpl{
+		message:                fmt.Sprintf("told to try again after %s", duration),
+		duration:               duration,
+		pollingSignalErrorType: PollingSignalErrorTypeTryAgainAfter,
+	}
+}
+
+type PollingSignalErrorAttachment struct {
+	Description string
+	Object      any
+}
+
+type PollingSignalErrorImpl struct {
+	message                string
+	wrappedErr             error
+	pollingSignalErrorType PollingSignalErrorType
+	duration               time.Duration
+	Attachments            []PollingSignalErrorAttachment
+}
+
+func (s *PollingSignalErrorImpl) Wrap(err error) PollingSignalError {
+	s.wrappedErr = err
+	return s
+}
+
+func (s *PollingSignalErrorImpl) Attach(description string, obj any) PollingSignalError {
+	s.Attachments = append(s.Attachments, PollingSignalErrorAttachment{description, obj})
+	return s
+}
+
+func (s *PollingSignalErrorImpl) Error() string {
+	if s.wrappedErr == nil {
+		return s.message
+	} else {
+		return s.message + ": " + s.wrappedErr.Error()
+	}
+}
+
+func (s *PollingSignalErrorImpl) Unwrap() error {
+	if s == nil {
+		return nil
+	}
+	return s.wrappedErr
+}
+
+func (s *PollingSignalErrorImpl) Now() {
+	panic(s)
+}
+
+func (s *PollingSignalErrorImpl) IsStopTrying() bool {
+	return s.pollingSignalErrorType == PollingSignalErrorTypeStopTrying
+}
+
+func (s *PollingSignalErrorImpl) IsTryAgainAfter() bool {
+	return s.pollingSignalErrorType == PollingSignalErrorTypeTryAgainAfter
+}
+
+func (s *PollingSignalErrorImpl) TryAgainDuration() time.Duration {
+	return s.duration
+}
+
+func AsPollingSignalError(actual interface{}) (*PollingSignalErrorImpl, bool) {
+	if actual == nil {
+		return nil, false
+	}
+	if actualErr, ok := actual.(error); ok {
+		var target *PollingSignalErrorImpl
+		if errors.As(actualErr, &target) {
+			return target, true
+		} else {
+			return nil, false
+		}
+	}
+
+	return nil, false
+}

--- a/vendor/github.com/onsi/gomega/matchers.go
+++ b/vendor/github.com/onsi/gomega/matchers.go
@@ -27,7 +27,8 @@ func BeEquivalentTo(expected interface{}) types.GomegaMatcher {
 	}
 }
 
-// BeComparableTo uses gocmp.Equal to compare. You can pass cmp.Option as options.
+// BeComparableTo uses gocmp.Equal from github.com/google/go-cmp (instead of reflect.DeepEqual) to perform a deep comparison.
+// You can pass cmp.Option as options.
 // It is an error for actual and expected to be nil.  Use BeNil() instead.
 func BeComparableTo(expected interface{}, opts ...cmp.Option) types.GomegaMatcher {
 	return &matchers.BeComparableToMatcher{

--- a/vendor/github.com/onsi/gomega/types/types.go
+++ b/vendor/github.com/onsi/gomega/types/types.go
@@ -19,11 +19,11 @@ type Gomega interface {
 	Expect(actual interface{}, extra ...interface{}) Assertion
 	ExpectWithOffset(offset int, actual interface{}, extra ...interface{}) Assertion
 
-	Eventually(actual interface{}, intervals ...interface{}) AsyncAssertion
-	EventuallyWithOffset(offset int, actual interface{}, intervals ...interface{}) AsyncAssertion
+	Eventually(args ...interface{}) AsyncAssertion
+	EventuallyWithOffset(offset int, args ...interface{}) AsyncAssertion
 
-	Consistently(actual interface{}, intervals ...interface{}) AsyncAssertion
-	ConsistentlyWithOffset(offset int, actual interface{}, intervals ...interface{}) AsyncAssertion
+	Consistently(args ...interface{}) AsyncAssertion
+	ConsistentlyWithOffset(offset int, args ...interface{}) AsyncAssertion
 
 	SetDefaultEventuallyTimeout(time.Duration)
 	SetDefaultEventuallyPollingInterval(time.Duration)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -51,7 +51,7 @@ github.com/mitchellh/mapstructure
 # github.com/olekukonko/tablewriter v0.0.5
 ## explicit; go 1.12
 github.com/olekukonko/tablewriter
-# github.com/onsi/ginkgo/v2 v2.4.0
+# github.com/onsi/ginkgo/v2 v2.5.0
 ## explicit; go 1.18
 github.com/onsi/ginkgo/v2
 github.com/onsi/ginkgo/v2/config

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -63,7 +63,7 @@ github.com/onsi/ginkgo/v2/internal/parallel_support
 github.com/onsi/ginkgo/v2/internal/testingtproxy
 github.com/onsi/ginkgo/v2/reporters
 github.com/onsi/ginkgo/v2/types
-# github.com/onsi/gomega v1.22.1
+# github.com/onsi/gomega v1.24.0
 ## explicit; go 1.18
 github.com/onsi/gomega
 github.com/onsi/gomega/format


### PR DESCRIPTION
This makes make verify happy for me locally.

- build(deps): bump github.com/onsi/gomega from 1.22.1 to 1.24.0
- build(deps): bump github.com/onsi/ginkgo/v2 from 2.4.0 to 2.5.0
- Do not use the deprecated io/ioutil module to make linter happy
