### PR TITLE
Use `semodule -lfull --checksum` instead of the datastore

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -39,7 +39,7 @@ func Daemon(opts *SelinuxdOptions, mPath string, sh seiface.Handler, ds datastor
 		defer ds.Close()
 	}
 
-	ss, err := initStatusServer(opts.StatusServerConfig, ds.GetReadOnly(), l)
+	ss, err := initStatusServer(opts.StatusServerConfig, ds.GetReadOnly(), sh, l, mPath)
 	if err != nil {
 		l.Error(err, "Unable initialize status server")
 		panic(err)

--- a/pkg/semodule/interface/interface.go
+++ b/pkg/semodule/interface/interface.go
@@ -5,6 +5,12 @@ import (
 	"fmt"
 )
 
+type PolicyModule struct {
+	Name     string
+	Ext      string
+	Checksum string
+}
+
 // errors
 var (
 	// ErrHandleCreate is an error when getting a handle to semanage
@@ -23,6 +29,8 @@ var (
 	ErrCannotInstallModule = errors.New("cannot install module")
 	// ErrCommit is an error when committing the changes to the SELinux policy
 	ErrCommit = errors.New("cannot commit changes to policy")
+	// ErrPolicyNotFound is an error policy is not found in SELinux policy modules store
+	ErrPolicyNotFound = errors.New("policy not found in SELinux store")
 )
 
 func NewErrCannotRemoveModule(mName string) error {
@@ -42,7 +50,8 @@ func NewErrCommit(origErrVal int, msg string) error {
 type Handler interface {
 	SetAutoCommit(bool)
 	Install(string) error
-	List() ([]string, error)
+	List() ([]PolicyModule, error)
+	GetPolicyModule(string) (PolicyModule, error)
 	Remove(string) error
 	Commit() error
 	Close() error

--- a/pkg/semodule/semanage/semanage.go
+++ b/pkg/semodule/semanage/semanage.go
@@ -14,12 +14,13 @@ void wrap_set_cb(semanage_handle_t *handle, void *arg);
 
 */
 import "C"
+
 import (
 	"bytes"
-	"github.com/containers/selinuxd/pkg/semodule/interface"
 	"sync"
 	"unsafe"
 
+	"github.com/containers/selinuxd/pkg/semodule/interface"
 	"github.com/go-logr/logr"
 )
 

--- a/pkg/semodule/test/testhandler.go
+++ b/pkg/semodule/test/testhandler.go
@@ -49,11 +49,34 @@ func (smt *SEModuleTestHandler) IsModuleInstalled(module string) bool {
 	return false
 }
 
-func (smt *SEModuleTestHandler) List() ([]string, error) {
+func (smt *SEModuleTestHandler) List() ([]seiface.PolicyModule, error) {
 	// Return a copy
 	smt.mu.Lock()
 	defer smt.mu.Unlock()
-	return append([]string(nil), smt.modules...), nil
+	policyModules := []seiface.PolicyModule{}
+	for _, module := range smt.modules {
+		m, err := smt.GetPolicyModule(module)
+		if err != nil {
+			return policyModules, err
+		}
+		policyModules = append(policyModules, m)
+	}
+	return policyModules, nil
+}
+
+func (smt *SEModuleTestHandler) GetPolicyModule(moduleName string) (seiface.PolicyModule, error) {
+	for _, mod := range smt.modules {
+		// The module had already been installed.
+		// Nothing to do
+		if mod == moduleName {
+			return seiface.PolicyModule{
+				Name:     moduleName,
+				Ext:      "cil",
+				Checksum: "sha256:e6c4d9c235af5d3ca50f660fc2283ecc330ebea73ec35241cc9cc47878dab68c",
+			}, nil
+		}
+	}
+	return seiface.PolicyModule{}, seiface.ErrPolicyNotFound
 }
 
 func (smt *SEModuleTestHandler) Remove(modToRemove string) error {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,7 +1,8 @@
 package utils
 
 import (
-	"crypto/sha512"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -35,17 +36,17 @@ func PolicyNameFromPath(path string) (string, error) {
 }
 
 // Checksum returns a checksum for a file on a given path
-func Checksum(path string) ([]byte, error) {
+func Checksum(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("unable to calculate checksum: %w", err)
+		return "", fmt.Errorf("unable to calculate checksum: %w", err)
 	}
 	defer f.Close()
 
-	h := sha512.New()
+	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
-		return nil, fmt.Errorf("unable to calculate checksum: %w", err)
+		return "", fmt.Errorf("unable to calculate checksum: %w", err)
 	}
 
-	return h.Sum(nil), nil
+	return fmt.Sprintf("sha256:%s", hex.EncodeToString(h.Sum(nil))), nil
 }


### PR DESCRIPTION
SELinux userspace release 3.4 introduced a new command line option [-m|--checksum] to `semodule` which adds sha256 checksum of modules to its output. It can be used to check whether the same module is already installed or not. Given that selinuxd installed modules use priority 350 we can  use semodule checksum and priority 350 as an indicator whether a module was already installed by selinuxd or not and therefore there's no need to track the state of modules in a separate datastore.

`semodule --checksum` is supported since Red Hat Enterprise Linux 8.6

Signed-off-by: Petr Lautrbach <lautrbach@redhat.com>