### PR TITLE
tests: Run GH actions on pushes to main only

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -1,5 +1,10 @@
 name: Build Images
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build-fedora:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -1,6 +1,10 @@
 name: build-and-test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build-selinuxd:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,6 +1,10 @@
 name: verify
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build-selinuxd:


### PR DESCRIPTION
We used to run GH actions on all pushes, even to topic branches and on
all pulls, which was racy and resulted in running some actions twice.

Let's run the actions on pulls and pushes to main only.
