### PR TITLE
e2e: Upgrade workers to macos-12

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
 
   e2e:
     needs: e2e-image
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 80
     strategy:
       matrix:
@@ -80,7 +80,7 @@ jobs:
 
   secure-e2e:
     needs: e2e-image
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 80
     strategy:
       matrix:


### PR DESCRIPTION
we were using mac 10 which might explain why our jobs took so long to
schedule.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
